### PR TITLE
Require that test targets have a host application

### DIFF
--- a/AccessibilitySnapshot/Classes/FBSnapshotTestCase+Accessibility.swift
+++ b/AccessibilitySnapshot/Classes/FBSnapshotTestCase+Accessibility.swift
@@ -44,11 +44,7 @@ extension FBSnapshotTestCase {
         file: StaticString = #file,
         line: UInt = #line
     ) {
-        // The tests must be run in a host application in order for the accessibility properties to be populated
-        // correctly. The `UIApplication.shared` singleton is non-optional, but will be uninitialized when the tests are
-        // running outside of a host application, so we can use this check to determine whether we have a test host.
-        let hostApplication: UIApplication? = UIApplication.shared
-        guard hostApplication != nil else {
+        guard isRunningInHostApplication else {
             XCTFail(
                 "Accessibility snapshot tests cannot be run in a test target without a host application",
                 file: file,
@@ -180,6 +176,16 @@ extension FBSnapshotTestCase {
         if requiresWindow {
             view.removeFromSuperview()
         }
+    }
+
+    // MARK: - Internal Properties
+
+    var isRunningInHostApplication: Bool {
+        // The tests must be run in a host application in order for the accessibility properties to be populated
+        // correctly. The `UIApplication.shared` singleton is non-optional, but will be uninitialized when the tests are
+        // running outside of a host application, so we can use this check to determine whether we have a test host.
+        let hostApplication: UIApplication? = UIApplication.shared
+        return (hostApplication != nil)
     }
 
 }

--- a/AccessibilitySnapshot/Classes/FBSnapshotTestCase+Accessibility.swift
+++ b/AccessibilitySnapshot/Classes/FBSnapshotTestCase+Accessibility.swift
@@ -44,6 +44,19 @@ extension FBSnapshotTestCase {
         file: StaticString = #file,
         line: UInt = #line
     ) {
+        // The tests must be run in a host application in order for the accessibility properties to be populated
+        // correctly. The `UIApplication.shared` singleton is non-optional, but will be uninitialized when the tests are
+        // running outside of a host application, so we can use this check to determine whether we have a test host.
+        let hostApplication: UIApplication? = UIApplication.shared
+        guard hostApplication != nil else {
+            XCTFail(
+                "Accessibility snapshot tests cannot be run in a test target without a host application",
+                file: file,
+                line: line
+            )
+            return
+        }
+
         let containerView = AccessibilitySnapshotView(
             containedView: view,
             viewRenderingMode: (usesDrawViewHierarchyInRect ? .drawHierarchyInRect : .renderLayerInContext),

--- a/AccessibilitySnapshot/Classes/FBSnapshotTestCase+ObjCSupport.swift
+++ b/AccessibilitySnapshot/Classes/FBSnapshotTestCase+ObjCSupport.swift
@@ -49,11 +49,7 @@ extension FBSnapshotTestCase {
         activationPointDisplayMode: ActivationPointDisplayMode,
         useMonochromeSnapshot: Bool
     ) -> String? {
-        // The tests must be run in a host application in order for the accessibility properties to be populated
-        // correctly. The `UIApplication.shared` singleton is non-optional, but will be uninitialized when the tests are
-        // running outside of a host application, so we can use this check to determine whether we have a test host.
-        let hostApplication: UIApplication? = UIApplication.shared
-        guard hostApplication != nil else {
+        guard isRunningInHostApplication else {
             return "Accessibility snapshot tests cannot be run in a test target without a host application"
         }
 

--- a/AccessibilitySnapshot/Classes/FBSnapshotTestCase+ObjCSupport.swift
+++ b/AccessibilitySnapshot/Classes/FBSnapshotTestCase+ObjCSupport.swift
@@ -49,6 +49,14 @@ extension FBSnapshotTestCase {
         activationPointDisplayMode: ActivationPointDisplayMode,
         useMonochromeSnapshot: Bool
     ) -> String? {
+        // The tests must be run in a host application in order for the accessibility properties to be populated
+        // correctly. The `UIApplication.shared` singleton is non-optional, but will be uninitialized when the tests are
+        // running outside of a host application, so we can use this check to determine whether we have a test host.
+        let hostApplication: UIApplication? = UIApplication.shared
+        guard hostApplication != nil else {
+            return "Accessibility snapshot tests cannot be run in a test target without a host application"
+        }
+
         let containerView = AccessibilitySnapshotView(
             containedView: view,
             viewRenderingMode: (usesDrawViewHierarchyInRect ? .drawHierarchyInRect : .renderLayerInContext),

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ AccessibilitySnapshots makes it simple to add regression tests for accessibility
 
 ## Getting Started
 
-AccessibilitySnapshot is built on top of [iOSSnapshotTestCase](https://github.com/uber/ios-snapshot-test-case). Before setting up accessibility snapshot tests, make sure your project is set up for standard snapshot testing.
+AccessibilitySnapshot is built on top of [iOSSnapshotTestCase](https://github.com/uber/ios-snapshot-test-case). Before setting up accessibility snapshot tests, make sure your project is set up for standard snapshot testing. Accessibility snapshot tests require that the test target has a host application.
 
 ### CocoaPods
 


### PR DESCRIPTION
Without a host application, many of the generated accessibility properties in UIKit won't be populated correctly, which can lead to things silently failing in less-than-obvious ways. This adds an assertion at the beginning of the test methods to check that the host application exists, and adds a note to the README about this requirement.