### PR TITLE
Add GitHub Actions for CI builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,45 @@
+name: CI
+
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+
+jobs:
+  xcode-build:
+    name: Xcode Build
+    runs-on: macOS-latest
+    strategy:
+      matrix:
+        platform: ['iOS_13']
+      fail-fast: false
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v2
+      - name: Bundle Install
+        run: bundle install --gemfile=Example/Gemfile
+      - name: Select Xcode Version
+        run: sudo xcode-select --switch /Applications/Xcode_11.3.1.app/Contents/Developer
+      - name: Pod Install
+        run: bundle exec --gemfile=Example/Gemfile pod install --project-directory=Example
+      - name: Build and Test
+        run: Scripts/build.swift xcode ${{ matrix.platform }} `which xcpretty`
+      - name: Upload Results
+        uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: Test Results
+          path: .build/derivedData/**/Logs/Test/*.xcresult
+  pod-lint:
+    name: Pod Lint
+    runs-on: macOS-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v2
+      - name: Bundle Install
+        run: bundle install --gemfile=Example/Gemfile
+      - name: Pod Install
+        run: bundle exec --gemfile=Example/Gemfile pod install --project-directory=Example
+      - name: Lint Podspec
+        run: bundle exec --gemfile=Example/Gemfile pod lib lint --verbose --fail-fast

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: objective-c
 jobs:
-  - osx_image: xcode11.3
-    env: ACTIONS="xcode,pod-lint";PLATFORM="iOS_13"
   - osx_image: xcode10.3
     env: ACTIONS="xcode";PLATFORM="iOS_12"
   - osx_image: xcode10.3

--- a/Scripts/build.swift
+++ b/Scripts/build.swift
@@ -61,6 +61,10 @@ enum Platform: String, CustomStringConvertible {
 		}
 	}
 
+	var derivedDataPath: String {
+		return ".build/derivedData/\(rawValue)"
+	}
+
 	var description: String {
 		return rawValue
 	}
@@ -136,6 +140,7 @@ xcodeBuildArguments.append(
 		"-sdk", "iphonesimulator",
 		"-PBXBuildsContinueAfterErrors=0",
 		"-destination", platform.destination,
+		"-derivedDataPath", platform.derivedDataPath,
 		"ONLY_ACTIVE_ARCH=NO",
 	]
 )


### PR DESCRIPTION
This moves us to a combination of GitHub Actions and Travis CI for our CI builds. This separation prefers GitHub Actions when available, since it has some advantages (more concurrent builds, artifact upload, etc.), but falls back to Travis CI for iOS versions that aren't easily supported with GitHub Actions.