### PR TITLE
Point demo app at master branch of Paralayout

### DIFF
--- a/Example/Podfile
+++ b/Example/Podfile
@@ -3,7 +3,9 @@ use_modular_headers!
 platform :ios, '10.0'
 
 target 'AccessibilitySnapshotDemo' do
-	pod 'Paralayout', '~> 0.9'
+	# Paralayout does not support Xcode 12 in the current release version. Support will be added in 1.0 (see
+	# square/Paralayout#23), so once that's released we can switch back to the release version.
+	pod 'Paralayout', :git => 'https://github.com/square/Paralayout'
 
 	target 'SnapshotTests' do
 		inherit! :search_paths

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -18,24 +18,30 @@ PODS:
 DEPENDENCIES:
   - AccessibilitySnapshot (from `../AccessibilitySnapshot.podspec`)
   - AccessibilitySnapshot/Core (from `../AccessibilitySnapshot.podspec`)
-  - Paralayout (~> 0.9)
+  - Paralayout (from `https://github.com/square/Paralayout`)
 
 SPEC REPOS:
   trunk:
     - fishhook
     - iOSSnapshotTestCase
-    - Paralayout
 
 EXTERNAL SOURCES:
   AccessibilitySnapshot:
     :path: "../AccessibilitySnapshot.podspec"
+  Paralayout:
+    :git: https://github.com/square/Paralayout
+
+CHECKOUT OPTIONS:
+  Paralayout:
+    :commit: 404a1f008b86463632edd2b76301e1c00bf90090
+    :git: https://github.com/square/Paralayout
 
 SPEC CHECKSUMS:
   AccessibilitySnapshot: fc706b52b64780cc00dbadda8b445320ff3ed17c
   fishhook: ea19933abfe8f2f52c55fd8b6e2718467d3ebc89
   iOSSnapshotTestCase: 9ab44cb5aa62b84d31847f40680112e15ec579a6
-  Paralayout: e36bf8c795ed9930159b9635ebb802d026667d0b
+  Paralayout: f4d6727fca5b592eb93a7cc408e45404599a4b0a
 
-PODFILE CHECKSUM: a46ca457f96c3770fea5e16fe5218c1408222d82
+PODFILE CHECKSUM: fff026bf6c6a44bd5ab7a336f2f0265ea56f3dbd
 
 COCOAPODS: 1.9.1


### PR DESCRIPTION
This updates the demo app's dependency on Paralayout to point at the `master` branch to fix a build issue in Xcode 12. This is not a dependency in AccessibilitySnapshot itself, so it should be safe to not be using a release version.