### PR TITLE
Change minimum supported iOS version to 11.0

### DIFF
--- a/AccessibilitySnapshot.podspec
+++ b/AccessibilitySnapshot.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
 
   s.swift_version = '5.0.1'
 
-  s.ios.deployment_target = '12.0'
+  s.ios.deployment_target = '11.0'
 
   s.default_subspecs = 'Core', 'iOSSnapshotTestCase'
 

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -43,7 +43,7 @@ CHECKOUT OPTIONS:
     :git: https://github.com/square/Paralayout
 
 SPEC CHECKSUMS:
-  AccessibilitySnapshot: 9f5bb086d87f4d797f4e047c46dcb06b0c7878f8
+  AccessibilitySnapshot: a2e53430e05659f6bf7b5972bdcfb204bdf3e7f8
   fishhook: ea19933abfe8f2f52c55fd8b6e2718467d3ebc89
   iOSSnapshotTestCase: 9ab44cb5aa62b84d31847f40680112e15ec579a6
   Paralayout: f4d6727fca5b592eb93a7cc408e45404599a4b0a


### PR DESCRIPTION
Testing this out to see if it fixes #29. If this works, it means that having the minimum version at 12.0 is the issue, and using 11.0 would be an option until we figure out the root cause of the flaky tests.

Running tally:
| Passed | Failed |
| :---: | :---: |
| 4 | 0 |