### PR TITLE
Create Accessibility Description SnapshotTesting Strategy

### DIFF
--- a/Example/AccessibilitySnapshot.xcodeproj/project.pbxproj
+++ b/Example/AccessibilitySnapshot.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		1635CE4E251EAC6700907101 /* SnapshotTestingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1635CE4D251EAC6700907101 /* SnapshotTestingTests.swift */; };
+		16EEB11D2534D54F008CF375 /* SnapshotTestingDescriptionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16EEB11C2534D54F008CF375 /* SnapshotTestingDescriptionTests.swift */; };
 		3D04B6D6211558B0006218A4 /* AccessibilityViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D04B6D5211558B0006218A4 /* AccessibilityViewController.swift */; };
 		3D04B6D921155942006218A4 /* LabelAccessibilityPropertiesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D04B6D821155942006218A4 /* LabelAccessibilityPropertiesViewController.swift */; };
 		3D04B6DB21155D92006218A4 /* ButtonAccessibilityTraitsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D04B6DA21155D92006218A4 /* ButtonAccessibilityTraitsViewController.swift */; };
@@ -75,6 +76,7 @@
 /* Begin PBXFileReference section */
 		0BFCB4FD6BC17AB232B26E72 /* Pods_UnitTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_UnitTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		1635CE4D251EAC6700907101 /* SnapshotTestingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnapshotTestingTests.swift; sourceTree = "<group>"; };
+		16EEB11C2534D54F008CF375 /* SnapshotTestingDescriptionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnapshotTestingDescriptionTests.swift; sourceTree = "<group>"; };
 		358D84DCD315110A89BD052E /* Pods-UnitTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-UnitTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-UnitTests/Pods-UnitTests.debug.xcconfig"; sourceTree = "<group>"; };
 		3A3192D7B9B16BD10FB517A2 /* Pods_SnapshotTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_SnapshotTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		3B8EB28BD6E6A6332C5D3115 /* LICENSE */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = LICENSE; path = ../LICENSE; sourceTree = "<group>"; };
@@ -299,6 +301,7 @@
 				3DC488382212B40C006D1E15 /* ModalTests.swift */,
 				3DF464FB220D4F430048D446 /* SnapshotTestCase.swift */,
 				1635CE4D251EAC6700907101 /* SnapshotTestingTests.swift */,
+				16EEB11C2534D54F008CF375 /* SnapshotTestingDescriptionTests.swift */,
 				3DBEAA5C2223C0CE00FAE61D /* SwitchControlsTests.swift */,
 				3DC8D05A224750F500E8A03C /* TextAccessibilityTests.swift */,
 				3D220A29252AF70600359C1E /* Utilities */,
@@ -625,6 +628,7 @@
 				3D13DB522221124000066519 /* ObjectiveCTests.m in Sources */,
 				3DC2C67C21F46020003184E4 /* HighlightTests.swift in Sources */,
 				3DF464FC220D4F430048D446 /* SnapshotTestCase.swift in Sources */,
+				16EEB11D2534D54F008CF375 /* SnapshotTestingDescriptionTests.swift in Sources */,
 				3D3F2E162263E94D00F7608E /* InvertColorsTests.swift in Sources */,
 				3D220A2B252AF72900359C1E /* AccessibleContainerView.swift in Sources */,
 				3DC8D05B224750F500E8A03C /* TextAccessibilityTests.swift in Sources */,

--- a/Example/SnapshotTests/SnapshotTestingDescriptionTests.swift
+++ b/Example/SnapshotTests/SnapshotTestingDescriptionTests.swift
@@ -1,0 +1,85 @@
+//
+//  Copyright 2020 Square Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import AccessibilitySnapshot
+import SnapshotTesting
+import XCTest
+
+@testable import AccessibilitySnapshotDemo
+
+/// Tests covering the integration between the core components of AccessibilitySnapshot and SnapshotTesting.
+final class SnapshotTestingDescriptionTests: XCTestCase {
+
+    // MARK: - Tests
+
+    func testDefaultConfiguration() {
+        let viewController = ViewAccessibilityPropertiesViewController()
+        viewController.view.frame = UIScreen.main.bounds
+        assertSnapshot(matching: viewController.view, as: .accessibilityDescription)
+        
+    }
+    
+    func testInline() {
+        let viewController = ViewAccessibilityPropertiesViewController()
+        viewController.view.frame = UIScreen.main.bounds
+        _assertInlineSnapshot(matching: viewController.view, as: .accessibilityDescription, with: """
+        Found 8 marker(s)
+        
+        No Fields
+        
+        Description: Label
+        
+        Description: Value
+        
+        Description: Hint
+        
+        Description: Label: Value
+        
+        Description: Label
+        Hint: Hint
+        
+        Description: Value
+        Hint: Hint
+        
+        Description: Label: Value
+        Hint: Hint
+        """)
+    }
+    
+    func testSingleView() {
+        let view = UILabel()
+        view.text = "Hello World"
+        view.textColor = .red
+        view.sizeToFit()
+        assertSnapshot(matching: view, as: .accessibilityDescription)
+    }
+    
+    func testNoMarkers() {
+        let view = UIView()
+        view.isAccessibilityElement = false
+        assertSnapshot(matching: view, as: .accessibilityDescription)
+    }
+    
+    func testAllFieldsConfiguration() {
+        let viewController = ViewAccessibilityPropertiesViewController()
+        viewController.view.frame = UIScreen.main.bounds
+        assertSnapshot(
+            matching: viewController.view,
+            as: .accessibilityDescription(fields: Snapshotting.AccessibilityFields.allCases)
+        )
+    }
+
+}

--- a/Example/SnapshotTests/__Snapshots__/SnapshotTestingDescriptionTests/testAllFieldsConfiguration.1.txt
+++ b/Example/SnapshotTests/__Snapshots__/SnapshotTestingDescriptionTests/testAllFieldsConfiguration.1.txt
@@ -1,0 +1,57 @@
+Found 8 marker(s)
+
+Description is Empty
+Hint is Empty
+Language is Empty
+Shape: Path
+Activation Point: 0.0, 0.0
+Custom Actions: None
+
+Description: Label
+Hint is Empty
+Language is Empty
+Shape: Path
+Activation Point: 0.0, 0.0
+Custom Actions: None
+
+Description: Value
+Hint is Empty
+Language is Empty
+Shape: Path
+Activation Point: 0.0, 0.0
+Custom Actions: None
+
+Description: Hint
+Hint is Empty
+Language is Empty
+Shape: Path
+Activation Point: 0.0, 0.0
+Custom Actions: None
+
+Description: Label: Value
+Hint is Empty
+Language is Empty
+Shape: Path
+Activation Point: 0.0, 0.0
+Custom Actions: None
+
+Description: Label
+Hint: Hint
+Language is Empty
+Shape: Path
+Activation Point: 0.0, 0.0
+Custom Actions: None
+
+Description: Value
+Hint: Hint
+Language is Empty
+Shape: Path
+Activation Point: 0.0, 0.0
+Custom Actions: None
+
+Description: Label: Value
+Hint: Hint
+Language is Empty
+Shape: Path
+Activation Point: 0.0, 0.0
+Custom Actions: None

--- a/Example/SnapshotTests/__Snapshots__/SnapshotTestingDescriptionTests/testDefaultConfiguration.1.txt
+++ b/Example/SnapshotTests/__Snapshots__/SnapshotTestingDescriptionTests/testDefaultConfiguration.1.txt
@@ -1,0 +1,25 @@
+Found 8 marker(s)
+
+Description is Empty
+Hint is Empty
+
+Description: Label
+Hint is Empty
+
+Description: Value
+Hint is Empty
+
+Description: Hint
+Hint is Empty
+
+Description: Label: Value
+Hint is Empty
+
+Description: Label
+Hint: Hint
+
+Description: Value
+Hint: Hint
+
+Description: Label: Value
+Hint: Hint

--- a/Example/SnapshotTests/__Snapshots__/SnapshotTestingDescriptionTests/testNoMarkers.1.txt
+++ b/Example/SnapshotTests/__Snapshots__/SnapshotTestingDescriptionTests/testNoMarkers.1.txt
@@ -1,0 +1,1 @@
+No Markers

--- a/Example/SnapshotTests/__Snapshots__/SnapshotTestingDescriptionTests/testSingleView.1.txt
+++ b/Example/SnapshotTests/__Snapshots__/SnapshotTestingDescriptionTests/testSingleView.1.txt
@@ -1,0 +1,2 @@
+Description: Hello World
+Hint is Empty


### PR DESCRIPTION
Sometimes a user may wish not to snapshot the visual part of their app as part of their accessibility tests. This strategy would give those users an alternative option using a textual representation of just the VoiceOver capability.