### PR TITLE
Mock VoiceOver status while running tests

### DIFF
--- a/AccessibilitySnapshot/Core/Classes/UIAccessibilityStatusUtility.h
+++ b/AccessibilitySnapshot/Core/Classes/UIAccessibilityStatusUtility.h
@@ -20,6 +20,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface UIAccessibilityStatusUtility : NSObject
 
+- (void)mockVoiceOverStatus;
+
 - (void)mockInvertColorsStatus;
 
 - (void)unmockStatuses;

--- a/AccessibilitySnapshot/Core/Classes/UIAccessibilityStatusUtility.m
+++ b/AccessibilitySnapshot/Core/Classes/UIAccessibilityStatusUtility.m
@@ -36,6 +36,12 @@
     return self;
 }
 
+- (void)mockVoiceOverStatus;
+{
+    [self mockStatusForFunction:&UIAccessibilityIsVoiceOverRunning
+                          named:"UIAccessibilityIsVoiceOverRunning"];
+}
+
 - (void)mockInvertColorsStatus;
 {
     [self mockStatusForFunction:&UIAccessibilityIsInvertColorsEnabled

--- a/Example/SnapshotTests/DefaultControlsTests.swift
+++ b/Example/SnapshotTests/DefaultControlsTests.swift
@@ -19,6 +19,32 @@ import FBSnapshotTestCase
 
 final class DefaultControlsTests: SnapshotTestCase {
 
+    static let statusUtility = UIAccessibilityStatusUtility()
+
+    override class func setUp() {
+        super.setUp()
+
+        statusUtility.mockVoiceOverStatus()
+
+        NotificationCenter.default.post(
+            name: UIAccessibility.voiceOverStatusDidChangeNotification,
+            object: nil,
+            userInfo: nil
+        )
+    }
+
+    override class func tearDown() {
+        statusUtility.unmockStatuses()
+
+        NotificationCenter.default.post(
+            name: UIAccessibility.voiceOverStatusDidChangeNotification,
+            object: nil,
+            userInfo: nil
+        )
+
+        super.tearDown()
+    }
+
     // MARK: - UIDatePicker
 
     // This test is disabled because the accessibility descriptions are not correct.


### PR DESCRIPTION
Testing this out to see if it fixes #29.

Specifically this would fix `testStepper` and `testStepperAtMin` only. If we see those two start passing consistently while `testTabBars` continues to flake, this is likely the solution.

Running tally:
| Passed | Failed |
| :---: | :---: |
| 2 | 1 |