### PR TITLE
Split CI jobs into separate workflows

### DIFF
--- a/.github/workflows/pod-lint.yml
+++ b/.github/workflows/pod-lint.yml
@@ -1,0 +1,21 @@
+name: CI
+
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+
+jobs:
+  pod-lint:
+    name: Pod Lint
+    runs-on: macOS-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v2
+      - name: Bundle Install
+        run: bundle install --gemfile=Example/Gemfile
+      - name: Pod Install
+        run: bundle exec --gemfile=Example/Gemfile pod install --project-directory=Example
+      - name: Lint Podspec
+        run: bundle exec --gemfile=Example/Gemfile pod lib lint --verbose --fail-fast

--- a/.github/workflows/xcode-build.yml
+++ b/.github/workflows/xcode-build.yml
@@ -31,15 +31,3 @@ jobs:
         with:
           name: Test Results
           path: .build/derivedData/**/Logs/Test/*.xcresult
-  pod-lint:
-    name: Pod Lint
-    runs-on: macOS-latest
-    steps:
-      - name: Checkout Repo
-        uses: actions/checkout@v2
-      - name: Bundle Install
-        run: bundle install --gemfile=Example/Gemfile
-      - name: Pod Install
-        run: bundle exec --gemfile=Example/Gemfile pod install --project-directory=Example
-      - name: Lint Podspec
-        run: bundle exec --gemfile=Example/Gemfile pod lib lint --verbose --fail-fast


### PR DESCRIPTION
Since GitHub Actions doesn't allow for restarting a single job, this breaks our large CI workflow into separate workflows for each of the job types. This makes it easier to debug flaky builds without having to restart as many jobs.