### PR TITLE
Use Xcode 11.6 for Travis CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: objective-c
 jobs:
-  - osx_image: xcode10.3
+  - osx_image: xcode11.6
     env: ACTIONS="xcode";PLATFORM="iOS_12"
 install:
   - bundle install --gemfile=Example/Gemfile


### PR DESCRIPTION
This switches us over to using Xcode 11.6 for our Travis CI build as we drop Xcode 10 support in 0.4.