### PR TITLE
Replace dependency on fishhook with inlined code

### DIFF
--- a/AccessibilitySnapshot.podspec
+++ b/AccessibilitySnapshot.podspec
@@ -23,8 +23,6 @@ Pod::Spec.new do |s|
     ss.resource_bundles = {
      'AccessibilitySnapshot' => ['AccessibilitySnapshot/Core/Assets/**/*.{strings,xcassets}']
     }
-
-    ss.dependency 'fishhook', '~> 0.2'
   end
 
   s.subspec 'iOSSnapshotTestCase' do |ss|

--- a/AccessibilitySnapshot/Core/Classes/UIAccessibilityStatusUtility.m
+++ b/AccessibilitySnapshot/Core/Classes/UIAccessibilityStatusUtility.m
@@ -100,16 +100,6 @@ struct rebinding {
 FISHHOOK_VISIBILITY
 int rebind_symbols(struct rebinding rebindings[], size_t rebindings_nel);
 
-/*
- * Rebinds as above, but only in the specified image. The header should point
- * to the mach-o header, the slide should be the slide offset. Others as above.
- */
-FISHHOOK_VISIBILITY
-int rebind_symbols_image(void *header,
-                         intptr_t slide,
-                         struct rebinding rebindings[],
-                         size_t rebindings_nel);
-
 struct rebindings_entry {
   struct rebinding *rebindings;
   size_t rebindings_nel;
@@ -278,20 +268,6 @@ static void rebind_symbols_for_image(struct rebindings_entry *rebindings,
 static void _rebind_symbols_for_image(const struct mach_header *header,
                                       intptr_t slide) {
     rebind_symbols_for_image(_rebindings_head, header, slide);
-}
-
-int rebind_symbols_image(void *header,
-                         intptr_t slide,
-                         struct rebinding rebindings[],
-                         size_t rebindings_nel) {
-    struct rebindings_entry *rebindings_head = NULL;
-    int retval = prepend_rebindings(&rebindings_head, rebindings, rebindings_nel);
-    rebind_symbols_for_image(rebindings_head, (const struct mach_header *) header, slide);
-    if (rebindings_head) {
-      free(rebindings_head->rebindings);
-    }
-    free(rebindings_head);
-    return retval;
 }
 
 int rebind_symbols(struct rebinding rebindings[], size_t rebindings_nel) {

--- a/AccessibilitySnapshot/Core/Classes/UIAccessibilityStatusUtility.m
+++ b/AccessibilitySnapshot/Core/Classes/UIAccessibilityStatusUtility.m
@@ -55,19 +55,10 @@
 #include <mach-o/loader.h>
 #include <mach-o/nlist.h>
 
-#ifdef __LP64__
 typedef struct mach_header_64 mach_header_t;
 typedef struct segment_command_64 segment_command_t;
 typedef struct section_64 section_t;
 typedef struct nlist_64 nlist_t;
-#define LC_SEGMENT_ARCH_DEPENDENT LC_SEGMENT_64
-#else
-typedef struct mach_header mach_header_t;
-typedef struct segment_command segment_command_t;
-typedef struct section section_t;
-typedef struct nlist nlist_t;
-#define LC_SEGMENT_ARCH_DEPENDENT LC_SEGMENT
-#endif
 
 #ifndef SEG_DATA_CONST
 #define SEG_DATA_CONST  "__DATA_CONST"
@@ -212,7 +203,7 @@ static void rebind_symbols_for_image(struct rebindings_entry *rebindings,
   uintptr_t cur = (uintptr_t)header + sizeof(mach_header_t);
   for (uint i = 0; i < header->ncmds; i++, cur += cur_seg_cmd->cmdsize) {
     cur_seg_cmd = (segment_command_t *)cur;
-    if (cur_seg_cmd->cmd == LC_SEGMENT_ARCH_DEPENDENT) {
+    if (cur_seg_cmd->cmd == LC_SEGMENT_64) {
       if (strcmp(cur_seg_cmd->segname, SEG_LINKEDIT) == 0) {
         linkedit_segment = cur_seg_cmd;
       }
@@ -239,7 +230,7 @@ static void rebind_symbols_for_image(struct rebindings_entry *rebindings,
   cur = (uintptr_t)header + sizeof(mach_header_t);
   for (uint i = 0; i < header->ncmds; i++, cur += cur_seg_cmd->cmdsize) {
     cur_seg_cmd = (segment_command_t *)cur;
-    if (cur_seg_cmd->cmd == LC_SEGMENT_ARCH_DEPENDENT) {
+    if (cur_seg_cmd->cmd == LC_SEGMENT_64) {
       if (strcmp(cur_seg_cmd->segname, SEG_DATA) != 0 &&
           strcmp(cur_seg_cmd->segname, SEG_DATA_CONST) != 0) {
         continue;

--- a/AccessibilitySnapshot/Core/Classes/UIAccessibilityStatusUtility.m
+++ b/AccessibilitySnapshot/Core/Classes/UIAccessibilityStatusUtility.m
@@ -71,9 +71,9 @@ struct rebinding {
 int rebind_symbols(struct rebinding rebindings[], size_t rebindings_nel);
 
 struct rebindings_entry {
-  struct rebinding *rebindings;
-  size_t rebindings_nel;
-  struct rebindings_entry *next;
+    struct rebinding *rebindings;
+    size_t rebindings_nel;
+    struct rebindings_entry *next;
 };
 
 static struct rebindings_entry *_rebindings_head;
@@ -81,36 +81,41 @@ static struct rebindings_entry *_rebindings_head;
 static int prepend_rebindings(struct rebindings_entry **rebindings_head,
                               struct rebinding rebindings[],
                               size_t nel) {
-  struct rebindings_entry *new_entry = (struct rebindings_entry *) malloc(sizeof(struct rebindings_entry));
-  if (!new_entry) {
-    return -1;
-  }
-  new_entry->rebindings = (struct rebinding *) malloc(sizeof(struct rebinding) * nel);
-  if (!new_entry->rebindings) {
-    free(new_entry);
-    return -1;
-  }
-  memcpy(new_entry->rebindings, rebindings, sizeof(struct rebinding) * nel);
-  new_entry->rebindings_nel = nel;
-  new_entry->next = *rebindings_head;
-  *rebindings_head = new_entry;
-  return 0;
+    struct rebindings_entry *new_entry = (struct rebindings_entry *) malloc(sizeof(struct rebindings_entry));
+    if (!new_entry) {
+        return -1;
+    }
+    new_entry->rebindings = (struct rebinding *) malloc(sizeof(struct rebinding) * nel);
+    if (!new_entry->rebindings) {
+        free(new_entry);
+        return -1;
+    }
+    memcpy(new_entry->rebindings, rebindings, sizeof(struct rebinding) * nel);
+    new_entry->rebindings_nel = nel;
+    new_entry->next = *rebindings_head;
+    *rebindings_head = new_entry;
+    return 0;
 }
 
 static vm_prot_t get_protection(void *sectionStart) {
-  mach_port_t task = mach_task_self();
-  vm_size_t size = 0;
-  vm_address_t address = (vm_address_t)sectionStart;
-  memory_object_name_t object;
-  mach_msg_type_number_t count = VM_REGION_BASIC_INFO_COUNT_64;
-  vm_region_basic_info_data_64_t info;
-  kern_return_t info_ret = vm_region_64(
-      task, &address, &size, VM_REGION_BASIC_INFO_64, (vm_region_info_64_t)&info, &count, &object);
-  if (info_ret == KERN_SUCCESS) {
-    return info.protection;
-  } else {
-    return VM_PROT_READ;
-  }
+    mach_port_t task = mach_task_self();
+    vm_size_t size = 0;
+    vm_address_t address = (vm_address_t)sectionStart;
+    memory_object_name_t object;
+    mach_msg_type_number_t count = VM_REGION_BASIC_INFO_COUNT_64;
+    vm_region_basic_info_data_64_t info;
+    kern_return_t info_ret = vm_region_64(task,
+                                          &address,
+                                          &size,
+                                          VM_REGION_BASIC_INFO_64,
+                                          (vm_region_info_64_t)&info,
+                                          &count,
+                                          &object);
+    if (info_ret == KERN_SUCCESS) {
+        return info.protection;
+    } else {
+        return VM_PROT_READ;
+    }
 }
 static void perform_rebinding_with_section(struct rebindings_entry *rebindings,
                                            section_t *section,
@@ -118,138 +123,137 @@ static void perform_rebinding_with_section(struct rebindings_entry *rebindings,
                                            nlist_t *symtab,
                                            char *strtab,
                                            uint32_t *indirect_symtab) {
-  const bool isDataConst = strcmp(section->segname, SEG_DATA_CONST) == 0;
-  uint32_t *indirect_symbol_indices = indirect_symtab + section->reserved1;
-  void **indirect_symbol_bindings = (void **)((uintptr_t)slide + section->addr);
-  vm_prot_t oldProtection = VM_PROT_READ;
-  if (isDataConst) {
-    oldProtection = get_protection(rebindings);
-    mprotect(indirect_symbol_bindings, section->size, PROT_READ | PROT_WRITE);
-  }
-  for (uint i = 0; i < section->size / sizeof(void *); i++) {
-    uint32_t symtab_index = indirect_symbol_indices[i];
-    if (symtab_index == INDIRECT_SYMBOL_ABS || symtab_index == INDIRECT_SYMBOL_LOCAL ||
-        symtab_index == (INDIRECT_SYMBOL_LOCAL   | INDIRECT_SYMBOL_ABS)) {
-      continue;
+    const bool isDataConst = strcmp(section->segname, SEG_DATA_CONST) == 0;
+    uint32_t *indirect_symbol_indices = indirect_symtab + section->reserved1;
+    void **indirect_symbol_bindings = (void **)((uintptr_t)slide + section->addr);
+    vm_prot_t oldProtection = VM_PROT_READ;
+    if (isDataConst) {
+        oldProtection = get_protection(rebindings);
+        mprotect(indirect_symbol_bindings, section->size, PROT_READ | PROT_WRITE);
     }
-    uint32_t strtab_offset = symtab[symtab_index].n_un.n_strx;
-    char *symbol_name = strtab + strtab_offset;
-    bool symbol_name_longer_than_1 = symbol_name[0] && symbol_name[1];
-    struct rebindings_entry *cur = rebindings;
-    while (cur) {
-      for (uint j = 0; j < cur->rebindings_nel; j++) {
-        if (symbol_name_longer_than_1 &&
-            strcmp(&symbol_name[1], cur->rebindings[j].name) == 0) {
-          if (cur->rebindings[j].replaced != NULL &&
-              indirect_symbol_bindings[i] != cur->rebindings[j].replacement) {
-            *(cur->rebindings[j].replaced) = indirect_symbol_bindings[i];
-          }
-          indirect_symbol_bindings[i] = cur->rebindings[j].replacement;
-          goto symbol_loop;
+    for (uint i = 0; i < section->size / sizeof(void *); i++) {
+        uint32_t symtab_index = indirect_symbol_indices[i];
+        if (symtab_index == INDIRECT_SYMBOL_ABS || symtab_index == INDIRECT_SYMBOL_LOCAL ||
+            symtab_index == (INDIRECT_SYMBOL_LOCAL   | INDIRECT_SYMBOL_ABS)) {
+            continue;
         }
-      }
-      cur = cur->next;
+        uint32_t strtab_offset = symtab[symtab_index].n_un.n_strx;
+        char *symbol_name = strtab + strtab_offset;
+        bool symbol_name_longer_than_1 = symbol_name[0] && symbol_name[1];
+        struct rebindings_entry *cur = rebindings;
+        while (cur) {
+            for (uint j = 0; j < cur->rebindings_nel; j++) {
+                if (symbol_name_longer_than_1 &&
+                    strcmp(&symbol_name[1], cur->rebindings[j].name) == 0) {
+                    if (cur->rebindings[j].replaced != NULL &&
+                        indirect_symbol_bindings[i] != cur->rebindings[j].replacement) {
+                        *(cur->rebindings[j].replaced) = indirect_symbol_bindings[i];
+                    }
+                    indirect_symbol_bindings[i] = cur->rebindings[j].replacement;
+                    goto symbol_loop;
+                }
+            }
+            cur = cur->next;
+        }
+    symbol_loop:;
     }
-  symbol_loop:;
-  }
-  if (isDataConst) {
-    int protection = 0;
-    if (oldProtection & VM_PROT_READ) {
-      protection |= PROT_READ;
+    if (isDataConst) {
+        int protection = 0;
+        if (oldProtection & VM_PROT_READ) {
+            protection |= PROT_READ;
+        }
+        if (oldProtection & VM_PROT_WRITE) {
+            protection |= PROT_WRITE;
+        }
+        if (oldProtection & VM_PROT_EXECUTE) {
+            protection |= PROT_EXEC;
+        }
+        mprotect(indirect_symbol_bindings, section->size, protection);
     }
-    if (oldProtection & VM_PROT_WRITE) {
-      protection |= PROT_WRITE;
-    }
-    if (oldProtection & VM_PROT_EXECUTE) {
-      protection |= PROT_EXEC;
-    }
-    mprotect(indirect_symbol_bindings, section->size, protection);
-  }
 }
 
 static void rebind_symbols_for_image(struct rebindings_entry *rebindings,
                                      const struct mach_header *header,
                                      intptr_t slide) {
-  Dl_info info;
-  if (dladdr(header, &info) == 0) {
-    return;
-  }
-
-  segment_command_t *cur_seg_cmd;
-  segment_command_t *linkedit_segment = NULL;
-  struct symtab_command* symtab_cmd = NULL;
-  struct dysymtab_command* dysymtab_cmd = NULL;
-
-  uintptr_t cur = (uintptr_t)header + sizeof(mach_header_t);
-  for (uint i = 0; i < header->ncmds; i++, cur += cur_seg_cmd->cmdsize) {
-    cur_seg_cmd = (segment_command_t *)cur;
-    if (cur_seg_cmd->cmd == LC_SEGMENT_64) {
-      if (strcmp(cur_seg_cmd->segname, SEG_LINKEDIT) == 0) {
-        linkedit_segment = cur_seg_cmd;
-      }
-    } else if (cur_seg_cmd->cmd == LC_SYMTAB) {
-      symtab_cmd = (struct symtab_command*)cur_seg_cmd;
-    } else if (cur_seg_cmd->cmd == LC_DYSYMTAB) {
-      dysymtab_cmd = (struct dysymtab_command*)cur_seg_cmd;
+    Dl_info info;
+    if (dladdr(header, &info) == 0) {
+        return;
     }
-  }
-
-  if (!symtab_cmd || !dysymtab_cmd || !linkedit_segment ||
-      !dysymtab_cmd->nindirectsyms) {
-    return;
-  }
-
-  // Find base symbol/string table addresses
-  uintptr_t linkedit_base = (uintptr_t)slide + linkedit_segment->vmaddr - linkedit_segment->fileoff;
-  nlist_t *symtab = (nlist_t *)(linkedit_base + symtab_cmd->symoff);
-  char *strtab = (char *)(linkedit_base + symtab_cmd->stroff);
-
-  // Get indirect symbol table (array of uint32_t indices into symbol table)
-  uint32_t *indirect_symtab = (uint32_t *)(linkedit_base + dysymtab_cmd->indirectsymoff);
-
-  cur = (uintptr_t)header + sizeof(mach_header_t);
-  for (uint i = 0; i < header->ncmds; i++, cur += cur_seg_cmd->cmdsize) {
-    cur_seg_cmd = (segment_command_t *)cur;
-    if (cur_seg_cmd->cmd == LC_SEGMENT_64) {
-      if (strcmp(cur_seg_cmd->segname, SEG_DATA) != 0 &&
-          strcmp(cur_seg_cmd->segname, SEG_DATA_CONST) != 0) {
-        continue;
-      }
-      for (uint j = 0; j < cur_seg_cmd->nsects; j++) {
-        section_t *sect =
-          (section_t *)(cur + sizeof(segment_command_t)) + j;
-        if ((sect->flags & SECTION_TYPE) == S_LAZY_SYMBOL_POINTERS) {
-          perform_rebinding_with_section(rebindings, sect, slide, symtab, strtab, indirect_symtab);
+    
+    segment_command_t *cur_seg_cmd;
+    segment_command_t *linkedit_segment = NULL;
+    struct symtab_command* symtab_cmd = NULL;
+    struct dysymtab_command* dysymtab_cmd = NULL;
+    
+    uintptr_t cur = (uintptr_t)header + sizeof(mach_header_t);
+    for (uint i = 0; i < header->ncmds; i++, cur += cur_seg_cmd->cmdsize) {
+        cur_seg_cmd = (segment_command_t *)cur;
+        if (cur_seg_cmd->cmd == LC_SEGMENT_64) {
+            if (strcmp(cur_seg_cmd->segname, SEG_LINKEDIT) == 0) {
+                linkedit_segment = cur_seg_cmd;
+            }
+        } else if (cur_seg_cmd->cmd == LC_SYMTAB) {
+            symtab_cmd = (struct symtab_command*)cur_seg_cmd;
+        } else if (cur_seg_cmd->cmd == LC_DYSYMTAB) {
+            dysymtab_cmd = (struct dysymtab_command*)cur_seg_cmd;
         }
-        if ((sect->flags & SECTION_TYPE) == S_NON_LAZY_SYMBOL_POINTERS) {
-          perform_rebinding_with_section(rebindings, sect, slide, symtab, strtab, indirect_symtab);
-        }
-      }
     }
-  }
+    
+    if (!symtab_cmd || !dysymtab_cmd || !linkedit_segment ||
+        !dysymtab_cmd->nindirectsyms) {
+        return;
+    }
+    
+    // Find base symbol/string table addresses
+    uintptr_t linkedit_base = (uintptr_t)slide + linkedit_segment->vmaddr - linkedit_segment->fileoff;
+    nlist_t *symtab = (nlist_t *)(linkedit_base + symtab_cmd->symoff);
+    char *strtab = (char *)(linkedit_base + symtab_cmd->stroff);
+    
+    // Get indirect symbol table (array of uint32_t indices into symbol table)
+    uint32_t *indirect_symtab = (uint32_t *)(linkedit_base + dysymtab_cmd->indirectsymoff);
+    
+    cur = (uintptr_t)header + sizeof(mach_header_t);
+    for (uint i = 0; i < header->ncmds; i++, cur += cur_seg_cmd->cmdsize) {
+        cur_seg_cmd = (segment_command_t *)cur;
+        if (cur_seg_cmd->cmd == LC_SEGMENT_64) {
+            if (strcmp(cur_seg_cmd->segname, SEG_DATA) != 0 &&
+                strcmp(cur_seg_cmd->segname, SEG_DATA_CONST) != 0) {
+                continue;
+            }
+            for (uint j = 0; j < cur_seg_cmd->nsects; j++) {
+                section_t *sect =
+                (section_t *)(cur + sizeof(segment_command_t)) + j;
+                if ((sect->flags & SECTION_TYPE) == S_LAZY_SYMBOL_POINTERS) {
+                    perform_rebinding_with_section(rebindings, sect, slide, symtab, strtab, indirect_symtab);
+                }
+                if ((sect->flags & SECTION_TYPE) == S_NON_LAZY_SYMBOL_POINTERS) {
+                    perform_rebinding_with_section(rebindings, sect, slide, symtab, strtab, indirect_symtab);
+                }
+            }
+        }
+    }
 }
 
-static void _rebind_symbols_for_image(const struct mach_header *header,
-                                      intptr_t slide) {
+static void _rebind_symbols_for_image(const struct mach_header *header, intptr_t slide) {
     rebind_symbols_for_image(_rebindings_head, header, slide);
 }
 
 int rebind_symbols(struct rebinding rebindings[], size_t rebindings_nel) {
-  int retval = prepend_rebindings(&_rebindings_head, rebindings, rebindings_nel);
-  if (retval < 0) {
-    return retval;
-  }
-  // If this was the first call, register callback for image additions (which is also invoked for
-  // existing images, otherwise, just run on existing images
-  if (!_rebindings_head->next) {
-    _dyld_register_func_for_add_image(_rebind_symbols_for_image);
-  } else {
-    uint32_t c = _dyld_image_count();
-    for (uint32_t i = 0; i < c; i++) {
-      _rebind_symbols_for_image(_dyld_get_image_header(i), _dyld_get_image_vmaddr_slide(i));
+    int retval = prepend_rebindings(&_rebindings_head, rebindings, rebindings_nel);
+    if (retval < 0) {
+        return retval;
     }
-  }
-  return retval;
+    // If this was the first call, register callback for image additions (which is also invoked for
+    // existing images, otherwise, just run on existing images
+    if (!_rebindings_head->next) {
+        _dyld_register_func_for_add_image(_rebind_symbols_for_image);
+    } else {
+        uint32_t c = _dyld_image_count();
+        for (uint32_t i = 0; i < c; i++) {
+            _rebind_symbols_for_image(_dyld_get_image_header(i), _dyld_get_image_vmaddr_slide(i));
+        }
+    }
+    return retval;
 }
 
 

--- a/AccessibilitySnapshot/Core/Classes/UIAccessibilityStatusUtility.m
+++ b/AccessibilitySnapshot/Core/Classes/UIAccessibilityStatusUtility.m
@@ -102,16 +102,10 @@ static vm_prot_t get_protection(void *sectionStart) {
   vm_size_t size = 0;
   vm_address_t address = (vm_address_t)sectionStart;
   memory_object_name_t object;
-#if __LP64__
   mach_msg_type_number_t count = VM_REGION_BASIC_INFO_COUNT_64;
   vm_region_basic_info_data_64_t info;
   kern_return_t info_ret = vm_region_64(
       task, &address, &size, VM_REGION_BASIC_INFO_64, (vm_region_info_64_t)&info, &count, &object);
-#else
-  mach_msg_type_number_t count = VM_REGION_BASIC_INFO_COUNT;
-  vm_region_basic_info_data_t info;
-  kern_return_t info_ret = vm_region(task, &address, &size, VM_REGION_BASIC_INFO, (vm_region_info_t)&info, &count, &object);
-#endif
   if (info_ret == KERN_SUCCESS) {
     return info.protection;
   } else {

--- a/AccessibilitySnapshot/Core/Classes/UIAccessibilityStatusUtility.m
+++ b/AccessibilitySnapshot/Core/Classes/UIAccessibilityStatusUtility.m
@@ -57,24 +57,17 @@ typedef struct nlist_64 nlist_t;
 #define SEG_DATA_CONST  "__DATA_CONST"
 #endif
 
-/*
- * A structure representing a particular intended rebinding from a symbol
- * name to its replacement
- */
+/// A structure representing a particular intended rebinding from a symbol name to its replacement.
 struct rebinding {
   const char *name;
   void *replacement;
   void **replaced;
 };
 
-/*
- * For each rebinding in rebindings, rebinds references to external, indirect
- * symbols with the specified name to instead point at replacement for each
- * image in the calling process as well as for all future images that are loaded
- * by the process. If rebind_functions is called more than once, the symbols to
- * rebind are added to the existing list of rebindings, and if a given symbol
- * is rebound more than once, the later rebinding will take precedence.
- */
+/// For each rebinding in rebindings, rebinds references to external, indirect symbols with the specified name to
+/// instead point at replacement for each image in the calling process as well as for all future images that are loaded
+/// by the process. If rebind_functions is called more than once, the symbols to rebind are added to the existing list
+/// of rebindings, and if a given symbol is rebound more than once, the later rebinding will take precedence.
 int rebind_symbols(struct rebinding rebindings[], size_t rebindings_nel);
 
 struct rebindings_entry {

--- a/AccessibilitySnapshot/Core/Classes/UIAccessibilityStatusUtility.m
+++ b/AccessibilitySnapshot/Core/Classes/UIAccessibilityStatusUtility.m
@@ -75,10 +75,6 @@ typedef struct nlist nlist_t;
 #define FISHHOOK_VISIBILITY __attribute__((visibility("default")))
 #endif
 
-#ifdef __cplusplus
-extern "C" {
-#endif //__cplusplus
-
 #ifndef SEG_DATA_CONST
 #define SEG_DATA_CONST  "__DATA_CONST"
 #endif
@@ -113,10 +109,6 @@ int rebind_symbols_image(void *header,
                          intptr_t slide,
                          struct rebinding rebindings[],
                          size_t rebindings_nel);
-
-#ifdef __cplusplus
-}
-#endif //__cplusplus
 
 struct rebindings_entry {
   struct rebinding *rebindings;

--- a/AccessibilitySnapshot/Core/Classes/UIAccessibilityStatusUtility.m
+++ b/AccessibilitySnapshot/Core/Classes/UIAccessibilityStatusUtility.m
@@ -173,6 +173,7 @@ static vm_prot_t get_protection(void *sectionStart) {
         return VM_PROT_READ;
     }
 }
+
 static void perform_rebinding_with_section(struct rebindings_entry *rebindings,
                                            section_t *section,
                                            intptr_t slide,

--- a/AccessibilitySnapshot/Core/Classes/UIAccessibilityStatusUtility.m
+++ b/AccessibilitySnapshot/Core/Classes/UIAccessibilityStatusUtility.m
@@ -43,16 +43,9 @@
 
 #import <dlfcn.h>
 
-#include <stdbool.h>
-#include <stdlib.h>
-#include <string.h>
 #include <sys/mman.h>
-#include <sys/types.h>
 #include <mach/mach.h>
-#include <mach/vm_map.h>
-#include <mach/vm_region.h>
 #include <mach-o/dyld.h>
-#include <mach-o/loader.h>
 #include <mach-o/nlist.h>
 
 typedef struct mach_header_64 mach_header_t;

--- a/AccessibilitySnapshot/Core/Classes/UIAccessibilityStatusUtility.m
+++ b/AccessibilitySnapshot/Core/Classes/UIAccessibilityStatusUtility.m
@@ -14,11 +14,312 @@
 //  limitations under the License.
 //
 
+// Some of the code in this file is originally from Fishhook, which has the following license:
+//
+// Copyright (c) 2013, Facebook, Inc.
+// All rights reserved.
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//   * Redistributions of source code must retain the above copyright notice,
+//     this list of conditions and the following disclaimer.
+//   * Redistributions in binary form must reproduce the above copyright notice,
+//     this list of conditions and the following disclaimer in the documentation
+//     and/or other materials provided with the distribution.
+//   * Neither the name Facebook nor the names of its contributors may be used to
+//     endorse or promote products derived from this software without specific
+//     prior written permission.
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
 #import "UIAccessibilityStatusUtility.h"
 
-@import fishhook;
-
 #import <dlfcn.h>
+
+#include <stdbool.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <sys/types.h>
+#include <mach/mach.h>
+#include <mach/vm_map.h>
+#include <mach/vm_region.h>
+#include <mach-o/dyld.h>
+#include <mach-o/loader.h>
+#include <mach-o/nlist.h>
+
+#ifdef __LP64__
+typedef struct mach_header_64 mach_header_t;
+typedef struct segment_command_64 segment_command_t;
+typedef struct section_64 section_t;
+typedef struct nlist_64 nlist_t;
+#define LC_SEGMENT_ARCH_DEPENDENT LC_SEGMENT_64
+#else
+typedef struct mach_header mach_header_t;
+typedef struct segment_command segment_command_t;
+typedef struct section section_t;
+typedef struct nlist nlist_t;
+#define LC_SEGMENT_ARCH_DEPENDENT LC_SEGMENT
+#endif
+
+#if !defined(FISHHOOK_EXPORT)
+#define FISHHOOK_VISIBILITY __attribute__((visibility("hidden")))
+#else
+#define FISHHOOK_VISIBILITY __attribute__((visibility("default")))
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif //__cplusplus
+
+#ifndef SEG_DATA_CONST
+#define SEG_DATA_CONST  "__DATA_CONST"
+#endif
+
+/*
+ * A structure representing a particular intended rebinding from a symbol
+ * name to its replacement
+ */
+struct rebinding {
+  const char *name;
+  void *replacement;
+  void **replaced;
+};
+
+/*
+ * For each rebinding in rebindings, rebinds references to external, indirect
+ * symbols with the specified name to instead point at replacement for each
+ * image in the calling process as well as for all future images that are loaded
+ * by the process. If rebind_functions is called more than once, the symbols to
+ * rebind are added to the existing list of rebindings, and if a given symbol
+ * is rebound more than once, the later rebinding will take precedence.
+ */
+FISHHOOK_VISIBILITY
+int rebind_symbols(struct rebinding rebindings[], size_t rebindings_nel);
+
+/*
+ * Rebinds as above, but only in the specified image. The header should point
+ * to the mach-o header, the slide should be the slide offset. Others as above.
+ */
+FISHHOOK_VISIBILITY
+int rebind_symbols_image(void *header,
+                         intptr_t slide,
+                         struct rebinding rebindings[],
+                         size_t rebindings_nel);
+
+#ifdef __cplusplus
+}
+#endif //__cplusplus
+
+struct rebindings_entry {
+  struct rebinding *rebindings;
+  size_t rebindings_nel;
+  struct rebindings_entry *next;
+};
+
+static struct rebindings_entry *_rebindings_head;
+
+static int prepend_rebindings(struct rebindings_entry **rebindings_head,
+                              struct rebinding rebindings[],
+                              size_t nel) {
+  struct rebindings_entry *new_entry = (struct rebindings_entry *) malloc(sizeof(struct rebindings_entry));
+  if (!new_entry) {
+    return -1;
+  }
+  new_entry->rebindings = (struct rebinding *) malloc(sizeof(struct rebinding) * nel);
+  if (!new_entry->rebindings) {
+    free(new_entry);
+    return -1;
+  }
+  memcpy(new_entry->rebindings, rebindings, sizeof(struct rebinding) * nel);
+  new_entry->rebindings_nel = nel;
+  new_entry->next = *rebindings_head;
+  *rebindings_head = new_entry;
+  return 0;
+}
+
+static vm_prot_t get_protection(void *sectionStart) {
+  mach_port_t task = mach_task_self();
+  vm_size_t size = 0;
+  vm_address_t address = (vm_address_t)sectionStart;
+  memory_object_name_t object;
+#if __LP64__
+  mach_msg_type_number_t count = VM_REGION_BASIC_INFO_COUNT_64;
+  vm_region_basic_info_data_64_t info;
+  kern_return_t info_ret = vm_region_64(
+      task, &address, &size, VM_REGION_BASIC_INFO_64, (vm_region_info_64_t)&info, &count, &object);
+#else
+  mach_msg_type_number_t count = VM_REGION_BASIC_INFO_COUNT;
+  vm_region_basic_info_data_t info;
+  kern_return_t info_ret = vm_region(task, &address, &size, VM_REGION_BASIC_INFO, (vm_region_info_t)&info, &count, &object);
+#endif
+  if (info_ret == KERN_SUCCESS) {
+    return info.protection;
+  } else {
+    return VM_PROT_READ;
+  }
+}
+static void perform_rebinding_with_section(struct rebindings_entry *rebindings,
+                                           section_t *section,
+                                           intptr_t slide,
+                                           nlist_t *symtab,
+                                           char *strtab,
+                                           uint32_t *indirect_symtab) {
+  const bool isDataConst = strcmp(section->segname, SEG_DATA_CONST) == 0;
+  uint32_t *indirect_symbol_indices = indirect_symtab + section->reserved1;
+  void **indirect_symbol_bindings = (void **)((uintptr_t)slide + section->addr);
+  vm_prot_t oldProtection = VM_PROT_READ;
+  if (isDataConst) {
+    oldProtection = get_protection(rebindings);
+    mprotect(indirect_symbol_bindings, section->size, PROT_READ | PROT_WRITE);
+  }
+  for (uint i = 0; i < section->size / sizeof(void *); i++) {
+    uint32_t symtab_index = indirect_symbol_indices[i];
+    if (symtab_index == INDIRECT_SYMBOL_ABS || symtab_index == INDIRECT_SYMBOL_LOCAL ||
+        symtab_index == (INDIRECT_SYMBOL_LOCAL   | INDIRECT_SYMBOL_ABS)) {
+      continue;
+    }
+    uint32_t strtab_offset = symtab[symtab_index].n_un.n_strx;
+    char *symbol_name = strtab + strtab_offset;
+    bool symbol_name_longer_than_1 = symbol_name[0] && symbol_name[1];
+    struct rebindings_entry *cur = rebindings;
+    while (cur) {
+      for (uint j = 0; j < cur->rebindings_nel; j++) {
+        if (symbol_name_longer_than_1 &&
+            strcmp(&symbol_name[1], cur->rebindings[j].name) == 0) {
+          if (cur->rebindings[j].replaced != NULL &&
+              indirect_symbol_bindings[i] != cur->rebindings[j].replacement) {
+            *(cur->rebindings[j].replaced) = indirect_symbol_bindings[i];
+          }
+          indirect_symbol_bindings[i] = cur->rebindings[j].replacement;
+          goto symbol_loop;
+        }
+      }
+      cur = cur->next;
+    }
+  symbol_loop:;
+  }
+  if (isDataConst) {
+    int protection = 0;
+    if (oldProtection & VM_PROT_READ) {
+      protection |= PROT_READ;
+    }
+    if (oldProtection & VM_PROT_WRITE) {
+      protection |= PROT_WRITE;
+    }
+    if (oldProtection & VM_PROT_EXECUTE) {
+      protection |= PROT_EXEC;
+    }
+    mprotect(indirect_symbol_bindings, section->size, protection);
+  }
+}
+
+static void rebind_symbols_for_image(struct rebindings_entry *rebindings,
+                                     const struct mach_header *header,
+                                     intptr_t slide) {
+  Dl_info info;
+  if (dladdr(header, &info) == 0) {
+    return;
+  }
+
+  segment_command_t *cur_seg_cmd;
+  segment_command_t *linkedit_segment = NULL;
+  struct symtab_command* symtab_cmd = NULL;
+  struct dysymtab_command* dysymtab_cmd = NULL;
+
+  uintptr_t cur = (uintptr_t)header + sizeof(mach_header_t);
+  for (uint i = 0; i < header->ncmds; i++, cur += cur_seg_cmd->cmdsize) {
+    cur_seg_cmd = (segment_command_t *)cur;
+    if (cur_seg_cmd->cmd == LC_SEGMENT_ARCH_DEPENDENT) {
+      if (strcmp(cur_seg_cmd->segname, SEG_LINKEDIT) == 0) {
+        linkedit_segment = cur_seg_cmd;
+      }
+    } else if (cur_seg_cmd->cmd == LC_SYMTAB) {
+      symtab_cmd = (struct symtab_command*)cur_seg_cmd;
+    } else if (cur_seg_cmd->cmd == LC_DYSYMTAB) {
+      dysymtab_cmd = (struct dysymtab_command*)cur_seg_cmd;
+    }
+  }
+
+  if (!symtab_cmd || !dysymtab_cmd || !linkedit_segment ||
+      !dysymtab_cmd->nindirectsyms) {
+    return;
+  }
+
+  // Find base symbol/string table addresses
+  uintptr_t linkedit_base = (uintptr_t)slide + linkedit_segment->vmaddr - linkedit_segment->fileoff;
+  nlist_t *symtab = (nlist_t *)(linkedit_base + symtab_cmd->symoff);
+  char *strtab = (char *)(linkedit_base + symtab_cmd->stroff);
+
+  // Get indirect symbol table (array of uint32_t indices into symbol table)
+  uint32_t *indirect_symtab = (uint32_t *)(linkedit_base + dysymtab_cmd->indirectsymoff);
+
+  cur = (uintptr_t)header + sizeof(mach_header_t);
+  for (uint i = 0; i < header->ncmds; i++, cur += cur_seg_cmd->cmdsize) {
+    cur_seg_cmd = (segment_command_t *)cur;
+    if (cur_seg_cmd->cmd == LC_SEGMENT_ARCH_DEPENDENT) {
+      if (strcmp(cur_seg_cmd->segname, SEG_DATA) != 0 &&
+          strcmp(cur_seg_cmd->segname, SEG_DATA_CONST) != 0) {
+        continue;
+      }
+      for (uint j = 0; j < cur_seg_cmd->nsects; j++) {
+        section_t *sect =
+          (section_t *)(cur + sizeof(segment_command_t)) + j;
+        if ((sect->flags & SECTION_TYPE) == S_LAZY_SYMBOL_POINTERS) {
+          perform_rebinding_with_section(rebindings, sect, slide, symtab, strtab, indirect_symtab);
+        }
+        if ((sect->flags & SECTION_TYPE) == S_NON_LAZY_SYMBOL_POINTERS) {
+          perform_rebinding_with_section(rebindings, sect, slide, symtab, strtab, indirect_symtab);
+        }
+      }
+    }
+  }
+}
+
+static void _rebind_symbols_for_image(const struct mach_header *header,
+                                      intptr_t slide) {
+    rebind_symbols_for_image(_rebindings_head, header, slide);
+}
+
+int rebind_symbols_image(void *header,
+                         intptr_t slide,
+                         struct rebinding rebindings[],
+                         size_t rebindings_nel) {
+    struct rebindings_entry *rebindings_head = NULL;
+    int retval = prepend_rebindings(&rebindings_head, rebindings, rebindings_nel);
+    rebind_symbols_for_image(rebindings_head, (const struct mach_header *) header, slide);
+    if (rebindings_head) {
+      free(rebindings_head->rebindings);
+    }
+    free(rebindings_head);
+    return retval;
+}
+
+int rebind_symbols(struct rebinding rebindings[], size_t rebindings_nel) {
+  int retval = prepend_rebindings(&_rebindings_head, rebindings, rebindings_nel);
+  if (retval < 0) {
+    return retval;
+  }
+  // If this was the first call, register callback for image additions (which is also invoked for
+  // existing images, otherwise, just run on existing images
+  if (!_rebindings_head->next) {
+    _dyld_register_func_for_add_image(_rebind_symbols_for_image);
+  } else {
+    uint32_t c = _dyld_image_count();
+    for (uint32_t i = 0; i < c; i++) {
+      _rebind_symbols_for_image(_dyld_get_image_header(i), _dyld_get_image_vmaddr_slide(i));
+    }
+  }
+  return retval;
+}
+
 
 @interface UIAccessibilityStatusUtility ()
 

--- a/AccessibilitySnapshot/Core/Classes/UIAccessibilityStatusUtility.m
+++ b/AccessibilitySnapshot/Core/Classes/UIAccessibilityStatusUtility.m
@@ -69,12 +69,6 @@ typedef struct nlist nlist_t;
 #define LC_SEGMENT_ARCH_DEPENDENT LC_SEGMENT
 #endif
 
-#if !defined(FISHHOOK_EXPORT)
-#define FISHHOOK_VISIBILITY __attribute__((visibility("hidden")))
-#else
-#define FISHHOOK_VISIBILITY __attribute__((visibility("default")))
-#endif
-
 #ifndef SEG_DATA_CONST
 #define SEG_DATA_CONST  "__DATA_CONST"
 #endif
@@ -97,7 +91,6 @@ struct rebinding {
  * rebind are added to the existing list of rebindings, and if a given symbol
  * is rebound more than once, the later rebinding will take precedence.
  */
-FISHHOOK_VISIBILITY
 int rebind_symbols(struct rebinding rebindings[], size_t rebindings_nel);
 
 struct rebindings_entry {

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,13 +1,11 @@
 PODS:
-  - AccessibilitySnapshot/Core (0.4.0):
-    - fishhook (~> 0.2)
+  - AccessibilitySnapshot/Core (0.4.0)
   - AccessibilitySnapshot/iOSSnapshotTestCase (0.4.0):
     - AccessibilitySnapshot/Core
     - iOSSnapshotTestCase (~> 6.0)
   - AccessibilitySnapshot/SnapshotTesting (0.4.0):
     - AccessibilitySnapshot/Core
     - SnapshotTesting (~> 1.0)
-  - fishhook (0.2)
   - iOSSnapshotTestCase (6.2.0):
     - iOSSnapshotTestCase/SwiftSupport (= 6.2.0)
   - iOSSnapshotTestCase/Core (6.2.0)
@@ -24,7 +22,6 @@ DEPENDENCIES:
 
 SPEC REPOS:
   trunk:
-    - fishhook
     - iOSSnapshotTestCase
     - SnapshotTesting
 
@@ -40,8 +37,7 @@ CHECKOUT OPTIONS:
     :git: https://github.com/square/Paralayout
 
 SPEC CHECKSUMS:
-  AccessibilitySnapshot: 82ee75a4b53b34b523f40bc476ca2dada35c098e
-  fishhook: ea19933abfe8f2f52c55fd8b6e2718467d3ebc89
+  AccessibilitySnapshot: cb80a36813f8897825eada35ca5b09b210e472c3
   iOSSnapshotTestCase: 9ab44cb5aa62b84d31847f40680112e15ec579a6
   Paralayout: f4d6727fca5b592eb93a7cc408e45404599a4b0a
   SnapshotTesting: 38947050d13960d57a4a9c166fcf51bca7d56970


### PR DESCRIPTION
Fishhook is currently blocking SPM support (#1) and hasn't been merging PRs recently, so it looks like that support likely isn't coming soon. This removes our dependency on Fishhook by inlining the code that we use from it. If Fishhook ends up getting more updates in the future, we can consider re-adding it as a dependency.

Probably easiest to review by commit. The first commit copies in the code from Fishhook and the remaining commits extract out parts of it that we don't need.