### PR TITLE
Make it possible to modify UIContentSizeCategory for Snapshot

### DIFF
--- a/AccessibilitySnapshot/SnapshotTesting/Classes/SnapshotTesting+Accessibility.swift
+++ b/AccessibilitySnapshot/SnapshotTesting/Classes/SnapshotTesting+Accessibility.swift
@@ -74,7 +74,7 @@ extension Snapshotting where Value == UIView, Format == UIImage {
     /// be made `public`.
     ///
     /// - parameter contentSizeCategory: The content size category to use in the snapshot
-    static func image(
+    public static func image(
         at contentSizeCategory: UIContentSizeCategory
     ) -> Snapshotting {
         return Snapshotting<UIView, UIImage>.image(
@@ -178,7 +178,7 @@ extension Snapshotting where Value == UIViewController, Format == UIImage {
     /// be made `public`.
     ///
     /// - parameter contentSizeCategory: The content size category to use in the snapshot
-    static func image(
+    public static func image(
         at contentSizeCategory: UIContentSizeCategory
     ) -> Snapshotting {
         return Snapshotting<UIView, UIImage>


### PR DESCRIPTION
Fixes #44 

Makes two functions inside the extension on `Snapshotting` for `UIView` and `UIViewController` in `SnapshotTesting+Accessibility.swift` public, so they can be used outside the target.

I'm not sure if this was an accident that the `public` keyword is missing or whether it was intended to stay internal. 

--> EDIT: reading the documentation of the function helps! It says that the feature is still under development, so it should stay internal... So feel free to close this until the development is finished. For the usage in our project this feature works fine, so I thought it would be great to make it public. 