### PR TITLE
Add `IDETemplateMacros.plist` to generate correct File Header

### DIFF
--- a/Example/AccessibilitySnapshot.xcodeproj/project.pbxproj
+++ b/Example/AccessibilitySnapshot.xcodeproj/project.pbxproj
@@ -406,7 +406,7 @@
 			attributes = {
 				LastSwiftUpdateCheck = 1130;
 				LastUpgradeCheck = 1030;
-				ORGANIZATIONNAME = CocoaPods;
+				ORGANIZATIONNAME = "Square Inc.";
 				TargetAttributes = {
 					3D881955246E03C00061DA6A = {
 						CreatedOnToolsVersion = 11.3;

--- a/Example/AccessibilitySnapshot.xcworkspace/xcshareddata/IDETemplateMacros.plist
+++ b/Example/AccessibilitySnapshot.xcworkspace/xcshareddata/IDETemplateMacros.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>FILEHEADER</key>
+	<string>
+//  Copyright ___YEAR___ ___ORGANIZATIONNAME___
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//</string>
+</dict>
+</plist>


### PR DESCRIPTION
Resolves #53 

This file is located under the example projects workspace (`Example/AccessibilitySnapshot.xcworkspace/xcshareddata/`), so it's shared with all developers working with the workspace. Tested this and Xcode now creates a new file with this content:

```swift
//
//  Copyright 2021 Square Inc.
//
//  Licensed under the Apache License, Version 2.0 (the "License");
//  you may not use this file except in compliance with the License.
//  You may obtain a copy of the License at
//
//  http://www.apache.org/licenses/LICENSE-2.0
//
//  Unless required by applicable law or agreed to in writing, software
//  distributed under the License is distributed on an "AS IS" BASIS,
//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
//  See the License for the specific language governing permissions and
//  limitations under the License.
//

import Foundation
```

To make it work I had to change the organization name of the workspace from `CocoaPods` to `Square Inc.`.