### PR TITLE
Add precision/tolerance to api

### DIFF
--- a/Example/SnapshotTests/ObjectiveCTests.m
+++ b/Example/SnapshotTests/ObjectiveCTests.m
@@ -90,6 +90,7 @@
     [view addSubview:label];
 
     SnapshotVerifyAccessibilityWithOptions(view, nil, YES, YES);
+    SnapshotVerifyAccessibilityWithOptionsAndTolerance(view, nil, YES, YES, 0, 0);
 }
 
 - (void)testSimpleViewWithActivationPointNever;
@@ -107,6 +108,7 @@
     label.accessibilityActivationPoint = CGPointMake(screenBounds.size.width / 2, screenBounds.size.height / 2 - 10);
 
     SnapshotVerifyAccessibilityWithOptions(view, nil, NO, YES);
+    SnapshotVerifyAccessibilityWithOptionsAndTolerance(view, nil, NO, YES, 0, 0);
 }
 
 - (void)testSimpleViewWithColorSnapshots;
@@ -124,6 +126,7 @@
     label.accessibilityActivationPoint = CGPointMake(screenBounds.size.width / 2, screenBounds.size.height / 2 - 10);
 
     SnapshotVerifyAccessibilityWithOptions(view, nil, NO, NO);
+    SnapshotVerifyAccessibilityWithOptionsAndTolerance(view, nil, NO, NO, 0, 0);
 }
 
 - (void)testViewWithInvertedColors;

--- a/Sources/AccessibilitySnapshot/SnapshotTesting/SnapshotTesting+Accessibility.swift
+++ b/Sources/AccessibilitySnapshot/SnapshotTesting/SnapshotTesting+Accessibility.swift
@@ -42,18 +42,20 @@ extension Snapshotting where Value == UIView, Format == UIImage {
     /// - parameter drawHierarchyInKeyWindow: Whether or not to draw the view hierachy in the key window, rather than
     /// rendering the view's layer. This enables the rendering of `UIAppearance` and `UIVisualEffect`s.
     /// - parameter markerColors: The array of colors which will be chosen from when creating the overlays
+    /// - parameter precision: The percentage of pixels that must match.
     public static func accessibilityImage(
         showActivationPoints activationPointDisplayMode: ActivationPointDisplayMode = .whenOverridden,
         useMonochromeSnapshot: Bool = true,
         drawHierarchyInKeyWindow: Bool = false,
-        markerColors: [UIColor] = []
+        markerColors: [UIColor] = [],
+        precision: Float = 1
     ) -> Snapshotting {
         guard isRunningInHostApplication else {
             fatalError("Accessibility snapshot tests cannot be run in a test target without a host application")
         }
 
         return Snapshotting<UIView, UIImage>
-            .image(drawHierarchyInKeyWindow: drawHierarchyInKeyWindow)
+            .image(drawHierarchyInKeyWindow: drawHierarchyInKeyWindow, precision: precision)
             .pullback { view in
                 let containerView = AccessibilitySnapshotView(
                     containedView: view,
@@ -160,18 +162,21 @@ extension Snapshotting where Value == UIViewController, Format == UIImage {
     /// - parameter drawHierarchyInKeyWindow: Whether or not to draw the view hierachy in the key window, rather than
     /// rendering the view's layer. This enables the rendering of `UIAppearance` and `UIVisualEffect`s.
     /// - parameter markerColors: The array of colors which will be chosen from when creating the overlays
+    /// - parameter precision: The percentage of pixels that must match.
     public static func accessibilityImage(
         showActivationPoints activationPointDisplayMode: ActivationPointDisplayMode = .whenOverridden,
         useMonochromeSnapshot: Bool = true,
         drawHierarchyInKeyWindow: Bool = false,
-        markerColors: [UIColor] = []
+        markerColors: [UIColor] = [],
+        precision: Float = 1
     ) -> Snapshotting {
         return Snapshotting<UIView, UIImage>
             .accessibilityImage(
                 showActivationPoints: activationPointDisplayMode,
                 useMonochromeSnapshot: useMonochromeSnapshot,
                 drawHierarchyInKeyWindow: drawHierarchyInKeyWindow,
-                markerColors: markerColors
+                markerColors: markerColors,
+                precision: precision
             )
             .pullback { viewController in
                 viewController.view

--- a/Sources/AccessibilitySnapshot/iOSSnapshotTestCase/FBSnapshotTestCase+Accessibility.swift
+++ b/Sources/AccessibilitySnapshot/iOSSnapshotTestCase/FBSnapshotTestCase+Accessibility.swift
@@ -78,9 +78,9 @@ extension FBSnapshotTestCase {
         FBSnapshotVerifyView(
           containerView,
           identifier: identifier,
-          suffixes: suffixes,
           perPixelTolerance: perPixelTolerance,
           overallTolerance: overallTolerance,
+          suffixes: suffixes,
           file: file,
           line: line
         )

--- a/Sources/AccessibilitySnapshot/iOSSnapshotTestCase/FBSnapshotTestCase+Accessibility.swift
+++ b/Sources/AccessibilitySnapshot/iOSSnapshotTestCase/FBSnapshotTestCase+Accessibility.swift
@@ -33,10 +33,10 @@ extension FBSnapshotTestCase {
     /// - parameter useMonochromeSnapshot: Whether or not the snapshot of the `view` should be monochrome. Using a
     /// monochrome snapshot makes it more clear where the highlighted elements are, but may make it difficult to
     /// read certain views. Defaults to `true`.
-    /// - parameter perPixelTolerance: The percentage a given pixel's R,G,B and A components can differ and still be considered 'identical'. Each color shade difference represents a 0.390625% change.
-    /// - parameter overallTolerance The percentage difference to still count as identical - 0 mean pixel perfect, 1 means I don't care.
     /// - parameter suffixes: NSOrderedSet object containing strings that are appended to the reference images directory.
     /// Defaults to `FBSnapshotTestCaseDefaultSuffixes()`.
+    /// - parameter perPixelTolerance: The percentage a given pixel's R,G,B and A components can differ and still be considered 'identical'. Each color shade difference represents a 0.390625% change.
+    /// - parameter overallTolerance The percentage difference to still count as identical - 0 mean pixel perfect, 1 means I don't care.
     /// - parameter file: The file in which the test result should be attributed.
     /// - parameter line: The line in which the test result should be attributed.
     public func SnapshotVerifyAccessibility(
@@ -45,9 +45,9 @@ extension FBSnapshotTestCase {
         showActivationPoints activationPointDisplayMode: ActivationPointDisplayMode = .whenOverridden,
         useMonochromeSnapshot: Bool = true,
         markerColors: [UIColor] = [],
+        suffixes: NSOrderedSet = FBSnapshotTestCaseDefaultSuffixes(),
         perPixelTolerance: CGFloat = 0,
         overallTolerance: CGFloat = 0,
-        suffixes: NSOrderedSet = FBSnapshotTestCaseDefaultSuffixes(),
         file: StaticString = #file,
         line: UInt = #line
     ) {
@@ -78,9 +78,9 @@ extension FBSnapshotTestCase {
         FBSnapshotVerifyView(
           containerView,
           identifier: identifier,
+          suffixes: suffixes,
           perPixelTolerance: perPixelTolerance,
           overallTolerance: overallTolerance,
-          suffixes: suffixes,
           file: file,
           line: line
         )
@@ -98,19 +98,19 @@ extension FBSnapshotTestCase {
     /// - parameter contentSizeCategory: The content size category to use in the snapshot.
     /// - parameter identifier: An optional identifier included in the snapshot name, for use when there are multiple snapshot tests
     /// in a given test method. Defaults to no identifier.
-    /// - parameter perPixelTolerance: The percentage a given pixel's R,G,B and A components can differ and still be considered 'identical'. Each color shade difference represents a 0.390625% change.
-    /// - parameter overallTolerance The percentage difference to still count as identical - 0 mean pixel perfect, 1 means I don't care.
     /// - parameter suffixes: NSOrderedSet object containing strings that are appended to the reference images directory.
     /// Defaults to `FBSnapshotTestCaseDefaultSuffixes()`.
+    /// - parameter perPixelTolerance: The percentage a given pixel's R,G,B and A components can differ and still be considered 'identical'. Each color shade difference represents a 0.390625% change.
+    /// - parameter overallTolerance The percentage difference to still count as identical - 0 mean pixel perfect, 1 means I don't care.
     /// - parameter file: The file in which the test result should be attributed.
     /// - parameter line: The line in which the test result should be attributed.
     func SnapshotVerify(
         _ view: UIView,
         at contentSizeCategory: UIContentSizeCategory,
         identifier: String = "",
+        suffixes: NSOrderedSet = FBSnapshotTestCaseDefaultSuffixes(),
         perPixelTolerance: CGFloat = 0,
         overallTolerance: CGFloat = 0,
-        suffixes: NSOrderedSet = FBSnapshotTestCaseDefaultSuffixes(),
         file: StaticString = #file,
         line: UInt = #line
     ) {
@@ -140,9 +140,9 @@ extension FBSnapshotTestCase {
         FBSnapshotVerifyView(
           view,
           identifier: identifier,
+          suffixes: suffixes,
           perPixelTolerance: perPixelTolerance,
           overallTolerance: overallTolerance,
-          suffixes: suffixes,
           file: file,
           line: line
         )
@@ -163,18 +163,18 @@ extension FBSnapshotTestCase {
     /// - parameter view: The view that will be snapshotted.
     /// - parameter identifier: An optional identifier included in the snapshot name, for use when there are multiple snapshot tests
     /// in a given test method. Defaults to no identifier.
-    /// - parameter perPixelTolerance: The percentage a given pixel's R,G,B and A components can differ and still be considered 'identical'. Each color shade difference represents a 0.390625% change.
-    /// - parameter overallTolerance The percentage difference to still count as identical - 0 mean pixel perfect, 1 means I don't care.
     /// - parameter suffixes: NSOrderedSet object containing strings that are appended to the reference images directory.
     /// Defaults to `FBSnapshotTestCaseDefaultSuffixes()`.
+    /// - parameter perPixelTolerance: The percentage a given pixel's R,G,B and A components can differ and still be considered 'identical'. Each color shade difference represents a 0.390625% change.
+    /// - parameter overallTolerance The percentage difference to still count as identical - 0 mean pixel perfect, 1 means I don't care.
     /// - parameter file: The file in which the test result should be attributed.
     /// - parameter line: The line in which the test result should be attributed.
     public func SnapshotVerifyWithInvertedColors(
         _ view: UIView,
         identifier: String = "",
+        suffixes: NSOrderedSet = FBSnapshotTestCaseDefaultSuffixes(),
         perPixelTolerance: CGFloat = 0,
         overallTolerance: CGFloat = 0,
-        suffixes: NSOrderedSet = FBSnapshotTestCaseDefaultSuffixes(),
         file: StaticString = #file,
         line: UInt = #line
     ) {
@@ -206,9 +206,9 @@ extension FBSnapshotTestCase {
         let imageView = UIImageView(image: image)
         FBSnapshotVerifyView(
           imageView,
+          suffixes: suffixes,
           perPixelTolerance: perPixelTolerance,
           overallTolerance: overallTolerance,
-          suffixes: suffixes,
           file: file,
           line: line
         )

--- a/Sources/AccessibilitySnapshot/iOSSnapshotTestCase/FBSnapshotTestCase+Accessibility.swift
+++ b/Sources/AccessibilitySnapshot/iOSSnapshotTestCase/FBSnapshotTestCase+Accessibility.swift
@@ -33,6 +33,8 @@ extension FBSnapshotTestCase {
     /// - parameter useMonochromeSnapshot: Whether or not the snapshot of the `view` should be monochrome. Using a
     /// monochrome snapshot makes it more clear where the highlighted elements are, but may make it difficult to
     /// read certain views. Defaults to `true`.
+    /// - parameter perPixelTolerance: The percentage a given pixel's R,G,B and A components can differ and still be considered 'identical'. Each color shade difference represents a 0.390625% change.
+    /// - parameter overallTolerance The percentage difference to still count as identical - 0 mean pixel perfect, 1 means I don't care.
     /// - parameter suffixes: NSOrderedSet object containing strings that are appended to the reference images directory.
     /// Defaults to `FBSnapshotTestCaseDefaultSuffixes()`.
     /// - parameter file: The file in which the test result should be attributed.
@@ -43,6 +45,8 @@ extension FBSnapshotTestCase {
         showActivationPoints activationPointDisplayMode: ActivationPointDisplayMode = .whenOverridden,
         useMonochromeSnapshot: Bool = true,
         markerColors: [UIColor] = [],
+        perPixelTolerance: CGFloat = 0,
+        overallTolerance: CGFloat = 0,
         suffixes: NSOrderedSet = FBSnapshotTestCaseDefaultSuffixes(),
         file: StaticString = #file,
         line: UInt = #line
@@ -71,7 +75,15 @@ extension FBSnapshotTestCase {
         containerView.parseAccessibility(useMonochromeSnapshot: useMonochromeSnapshot)
         containerView.sizeToFit()
 
-        FBSnapshotVerifyView(containerView, identifier: identifier, suffixes: suffixes, file: file, line: line)
+        FBSnapshotVerifyView(
+          containerView,
+          identifier: identifier,
+          suffixes: suffixes,
+          perPixelTolerance: perPixelTolerance,
+          overallTolerance: overallTolerance,
+          file: file,
+          line: line
+        )
     }
 
     /// Snapshots the `view` using the specified content size category to test Dynamic Type.
@@ -86,6 +98,8 @@ extension FBSnapshotTestCase {
     /// - parameter contentSizeCategory: The content size category to use in the snapshot.
     /// - parameter identifier: An optional identifier included in the snapshot name, for use when there are multiple snapshot tests
     /// in a given test method. Defaults to no identifier.
+    /// - parameter perPixelTolerance: The percentage a given pixel's R,G,B and A components can differ and still be considered 'identical'. Each color shade difference represents a 0.390625% change.
+    /// - parameter overallTolerance The percentage difference to still count as identical - 0 mean pixel perfect, 1 means I don't care.
     /// - parameter suffixes: NSOrderedSet object containing strings that are appended to the reference images directory.
     /// Defaults to `FBSnapshotTestCaseDefaultSuffixes()`.
     /// - parameter file: The file in which the test result should be attributed.
@@ -94,6 +108,8 @@ extension FBSnapshotTestCase {
         _ view: UIView,
         at contentSizeCategory: UIContentSizeCategory,
         identifier: String = "",
+        perPixelTolerance: CGFloat = 0,
+        overallTolerance: CGFloat = 0,
         suffixes: NSOrderedSet = FBSnapshotTestCaseDefaultSuffixes(),
         file: StaticString = #file,
         line: UInt = #line
@@ -121,7 +137,15 @@ extension FBSnapshotTestCase {
         // will be able to change the text size in production.
         view.setNeedsLayout()
 
-        FBSnapshotVerifyView(view, identifier: identifier, suffixes: suffixes, file: file, line: line)
+        FBSnapshotVerifyView(
+          view,
+          identifier: identifier,
+          perPixelTolerance: perPixelTolerance,
+          overallTolerance: overallTolerance,
+          suffixes: suffixes,
+          file: file,
+          line: line
+        )
 
         // Restore the original content size category.
         let overriddenTraitCollection = view.traitCollection
@@ -139,6 +163,8 @@ extension FBSnapshotTestCase {
     /// - parameter view: The view that will be snapshotted.
     /// - parameter identifier: An optional identifier included in the snapshot name, for use when there are multiple snapshot tests
     /// in a given test method. Defaults to no identifier.
+    /// - parameter perPixelTolerance: The percentage a given pixel's R,G,B and A components can differ and still be considered 'identical'. Each color shade difference represents a 0.390625% change.
+    /// - parameter overallTolerance The percentage difference to still count as identical - 0 mean pixel perfect, 1 means I don't care.
     /// - parameter suffixes: NSOrderedSet object containing strings that are appended to the reference images directory.
     /// Defaults to `FBSnapshotTestCaseDefaultSuffixes()`.
     /// - parameter file: The file in which the test result should be attributed.
@@ -146,6 +172,8 @@ extension FBSnapshotTestCase {
     public func SnapshotVerifyWithInvertedColors(
         _ view: UIView,
         identifier: String = "",
+        perPixelTolerance: CGFloat = 0,
+        overallTolerance: CGFloat = 0,
         suffixes: NSOrderedSet = FBSnapshotTestCaseDefaultSuffixes(),
         file: StaticString = #file,
         line: UInt = #line
@@ -176,7 +204,14 @@ extension FBSnapshotTestCase {
         }
 
         let imageView = UIImageView(image: image)
-        FBSnapshotVerifyView(imageView, suffixes: suffixes, file: file, line: line)
+        FBSnapshotVerifyView(
+          imageView,
+          perPixelTolerance: perPixelTolerance,
+          overallTolerance: overallTolerance,
+          suffixes: suffixes,
+          file: file,
+          line: line
+        )
 
         statusUtility.unmockStatuses()
         postNotification()

--- a/Sources/AccessibilitySnapshot/iOSSnapshotTestCase/FBSnapshotTestCase+ObjCSupport.swift
+++ b/Sources/AccessibilitySnapshot/iOSSnapshotTestCase/FBSnapshotTestCase+ObjCSupport.swift
@@ -33,7 +33,9 @@ extension FBSnapshotTestCase {
         _ view: UIView,
         identifier: String,
         showActivationPoints: Bool,
-        useMonochromeSnapshot: Bool
+        useMonochromeSnapshot: Bool,
+        perPixelTolerance: CGFloat = 0,
+        overallTolerance: CGFloat = 0
     ) -> String? {
         return snapshotVerifyAccessibility(
             view,
@@ -47,7 +49,9 @@ extension FBSnapshotTestCase {
         _ view: UIView,
         identifier: String,
         activationPointDisplayMode: ActivationPointDisplayMode,
-        useMonochromeSnapshot: Bool
+        useMonochromeSnapshot: Bool,
+        perPixelTolerance: CGFloat = 0,
+        overallTolerance: CGFloat = 0
     ) -> String? {
         guard isRunningInHostApplication else {
             return "Accessibility snapshot tests cannot be run in a test target without a host application"
@@ -71,15 +75,20 @@ extension FBSnapshotTestCase {
             containerView,
             identifier: identifier,
             suffixes: FBSnapshotTestCaseDefaultSuffixes(),
-            perPixelTolerance: 0,
-            overallTolerance: 0,
+            perPixelTolerance: perPixelTolerance,
+            overallTolerance: overallTolerance,
             defaultReferenceDirectory: FB_REFERENCE_IMAGE_DIR,
             defaultImageDiffDirectory: IMAGE_DIFF_DIR
         )
     }
 
     @objc(snapshotVerifyWithInvertedColors:identifier:)
-    private func snapshotVerifyWithInvertedColors(_ view: UIView, identifier: String) -> String? {
+    private func snapshotVerifyWithInvertedColors(
+      _ view: UIView,
+      identifier: String,
+      perPixelTolerance: CGFloat = 0,
+      overallTolerance: CGFloat = 0
+    ) -> String? {
         func postNotification() {
             NotificationCenter.default.post(
                 name: UIAccessibility.invertColorsStatusDidChangeNotification,
@@ -110,8 +119,8 @@ extension FBSnapshotTestCase {
             imageView,
             identifier: identifier,
             suffixes: FBSnapshotTestCaseDefaultSuffixes(),
-            perPixelTolerance: 0,
-            overallTolerance: 0,
+            perPixelTolerance: perPixelTolerance,
+            overallTolerance: overallTolerance,
             defaultReferenceDirectory: FB_REFERENCE_IMAGE_DIR,
             defaultImageDiffDirectory: IMAGE_DIFF_DIR
         )
@@ -125,5 +134,4 @@ extension FBSnapshotTestCase {
 
         return errorDescription
     }
-
 }

--- a/Sources/AccessibilitySnapshot/iOSSnapshotTestCase/FBSnapshotTestCase+ObjCSupport.swift
+++ b/Sources/AccessibilitySnapshot/iOSSnapshotTestCase/FBSnapshotTestCase+ObjCSupport.swift
@@ -35,7 +35,7 @@ extension FBSnapshotTestCase {
         showActivationPoints: Bool,
         useMonochromeSnapshot: Bool
     ) -> String? {
-        return  🚫objc_snapshotVerifyAccessibility(
+        return 🚫objc_snapshotVerifyAccessibility(
             view,
             identifier: identifier,
             showActivationPoints: showActivationPoints,
@@ -105,7 +105,7 @@ extension FBSnapshotTestCase {
       _ view: UIView,
       identifier: String
     ) -> String? {
-      snapshotVerifyWithInvertedColors(view, identifier: identifier, perPixelTolerance: 0, overallTolerance: 0)
+      return snapshotVerifyWithInvertedColors(view, identifier: identifier, perPixelTolerance: 0, overallTolerance: 0)
     }
 
     @objc(snapshotVerifyWithInvertedColors:identifier:perPixelTolerance:overallTolerance:)

--- a/Sources/AccessibilitySnapshot/iOSSnapshotTestCase/FBSnapshotTestCase+ObjCSupport.swift
+++ b/Sources/AccessibilitySnapshot/iOSSnapshotTestCase/FBSnapshotTestCase+ObjCSupport.swift
@@ -28,20 +28,39 @@ extension FBSnapshotTestCase {
         )
     }
 
-	@objc(snapshotVerifyAccessibility:identifier:showActivationPoints:useMonochromeSnapshot:perPixelTolerance:overallTolerance:)
+    @objc(snapshotVerifyAccessibility:identifier:showActivationPoints:useMonochromeSnapshot:)
+    private func 🚫objc_snapshotVerifyAccessibility(
+        _ view: UIView,
+        identifier: String,
+        showActivationPoints: Bool,
+        useMonochromeSnapshot: Bool
+    ) -> String? {
+        return  🚫objc_snapshotVerifyAccessibility(
+            view,
+            identifier: identifier,
+            showActivationPoints: showActivationPoints,
+            useMonochromeSnapshot: useMonochromeSnapshot,
+            perPixelTolerance: 0,
+            overallTolerance: 0
+        )
+    }
+
+    @objc(snapshotVerifyAccessibility:identifier:showActivationPoints:useMonochromeSnapshot:perPixelTolerance:overallTolerance:)
     private func 🚫objc_snapshotVerifyAccessibility(
         _ view: UIView,
         identifier: String,
         showActivationPoints: Bool,
         useMonochromeSnapshot: Bool,
-        perPixelTolerance: CGFloat = 0,
-        overallTolerance: CGFloat = 0
+        perPixelTolerance: CGFloat,
+        overallTolerance: CGFloat
     ) -> String? {
         return snapshotVerifyAccessibility(
             view,
             identifier: identifier,
             activationPointDisplayMode: showActivationPoints ? .always : .never,
-            useMonochromeSnapshot: useMonochromeSnapshot
+            useMonochromeSnapshot: useMonochromeSnapshot,
+            perPixelTolerance: perPixelTolerance,
+            overallTolerance: overallTolerance
         )
     }
 
@@ -74,20 +93,27 @@ extension FBSnapshotTestCase {
         return snapshotVerifyViewOrLayer(
             containerView,
             identifier: identifier,
-            perPixelTolerance: perPixelTolerance,
+            suffixes: FBSnapshotTestCaseDefaultSuffixes(), perPixelTolerance: perPixelTolerance,
             overallTolerance: overallTolerance,
-            suffixes: FBSnapshotTestCaseDefaultSuffixes(),
             defaultReferenceDirectory: FB_REFERENCE_IMAGE_DIR,
             defaultImageDiffDirectory: IMAGE_DIFF_DIR
         )
     }
 
-	@objc(snapshotVerifyWithInvertedColors:identifier:perPixelTolerance:overallTolerance:)
+    @objc(snapshotVerifyWithInvertedColors:identifier:)
+    private func snapshotVerifyWithInvertedColors(
+      _ view: UIView,
+      identifier: String
+    ) -> String? {
+      snapshotVerifyWithInvertedColors(view, identifier: identifier, perPixelTolerance: 0, overallTolerance: 0)
+    }
+
+    @objc(snapshotVerifyWithInvertedColors:identifier:perPixelTolerance:overallTolerance:)
     private func snapshotVerifyWithInvertedColors(
       _ view: UIView,
       identifier: String,
-      perPixelTolerance: CGFloat = 0,
-      overallTolerance: CGFloat = 0
+      perPixelTolerance: CGFloat,
+      overallTolerance: CGFloat
     ) -> String? {
         func postNotification() {
             NotificationCenter.default.post(
@@ -118,9 +144,8 @@ extension FBSnapshotTestCase {
         let errorDescription = snapshotVerifyViewOrLayer(
             imageView,
             identifier: identifier,
-            perPixelTolerance: perPixelTolerance,
+            suffixes: FBSnapshotTestCaseDefaultSuffixes(), perPixelTolerance: perPixelTolerance,
             overallTolerance: overallTolerance,
-            suffixes: FBSnapshotTestCaseDefaultSuffixes(),
             defaultReferenceDirectory: FB_REFERENCE_IMAGE_DIR,
             defaultImageDiffDirectory: IMAGE_DIFF_DIR
         )

--- a/Sources/AccessibilitySnapshot/iOSSnapshotTestCase/FBSnapshotTestCase+ObjCSupport.swift
+++ b/Sources/AccessibilitySnapshot/iOSSnapshotTestCase/FBSnapshotTestCase+ObjCSupport.swift
@@ -28,7 +28,7 @@ extension FBSnapshotTestCase {
         )
     }
 
-    @objc(snapshotVerifyAccessibility:identifier:showActivationPoints:useMonochromeSnapshot:)
+	@objc(snapshotVerifyAccessibility:identifier:showActivationPoints:useMonochromeSnapshot:perPixelTolerance:overallTolerance:)
     private func 🚫objc_snapshotVerifyAccessibility(
         _ view: UIView,
         identifier: String,
@@ -74,15 +74,15 @@ extension FBSnapshotTestCase {
         return snapshotVerifyViewOrLayer(
             containerView,
             identifier: identifier,
-            suffixes: FBSnapshotTestCaseDefaultSuffixes(),
             perPixelTolerance: perPixelTolerance,
             overallTolerance: overallTolerance,
+            suffixes: FBSnapshotTestCaseDefaultSuffixes(),
             defaultReferenceDirectory: FB_REFERENCE_IMAGE_DIR,
             defaultImageDiffDirectory: IMAGE_DIFF_DIR
         )
     }
 
-    @objc(snapshotVerifyWithInvertedColors:identifier:)
+	@objc(snapshotVerifyWithInvertedColors:identifier:perPixelTolerance:overallTolerance:)
     private func snapshotVerifyWithInvertedColors(
       _ view: UIView,
       identifier: String,
@@ -118,9 +118,9 @@ extension FBSnapshotTestCase {
         let errorDescription = snapshotVerifyViewOrLayer(
             imageView,
             identifier: identifier,
-            suffixes: FBSnapshotTestCaseDefaultSuffixes(),
             perPixelTolerance: perPixelTolerance,
             overallTolerance: overallTolerance,
+            suffixes: FBSnapshotTestCaseDefaultSuffixes(),
             defaultReferenceDirectory: FB_REFERENCE_IMAGE_DIR,
             defaultImageDiffDirectory: IMAGE_DIFF_DIR
         )

--- a/Sources/AccessibilitySnapshot/iOSSnapshotTestCase/FBSnapshotTestCase_Accessibility.h
+++ b/Sources/AccessibilitySnapshot/iOSSnapshotTestCase/FBSnapshotTestCase_Accessibility.h
@@ -48,6 +48,22 @@
         }\
     }
 
+#define SnapshotVerifyAccessibilityWithOptionsAndTolerance(view__, identifier__, showActivationPoints__, useMonochromeSnapshot__, perPixelTolerance__, overallTolerance__)\
+    {\
+        _Pragma("clang diagnostic push")\
+        _Pragma("clang diagnostic ignored \"-Wundeclared-selector\"")\
+        SEL selector = @selector(snapshotVerifyAccessibility:identifier:showActivationPoints:useMonochromeSnapshot:perPixelTolerance:overallTolerance:);\
+        _Pragma("clang diagnostic pop")\
+        typedef NSString * (*SnapshotMethod)(id, SEL, UIView *, NSString *, BOOL, BOOL, CGFloat, CGFloat);\
+        SnapshotMethod snapshotVerifyAccessibility = (SnapshotMethod)[self methodForSelector:selector];\
+        NSString *errorDescription = snapshotVerifyAccessibility(self, selector, view__, identifier__ ?: @"", showActivationPoints__, useMonochromeSnapshot__, perPixelTolerance__, overallTolerance__);\
+        if (errorDescription == nil) {\
+            XCTAssertTrue(YES);\
+        } else {\
+            XCTFail("%@", errorDescription);\
+        }\
+    }
+
 #define SnapshotVerifyWithInvertedColors(view__, identifier__)\
     {\
         _Pragma("clang diagnostic push")\
@@ -57,6 +73,22 @@
         typedef NSString * (*SnapshotMethod)(id, SEL, UIView *, NSString *);\
         SnapshotMethod snapshotVerifyWithInvertedColors = (SnapshotMethod)[self methodForSelector:selector];\
         NSString *errorDescription = snapshotVerifyWithInvertedColors(self, selector, view__, identifier__ ?: @"");\
+        if (errorDescription == nil) {\
+            XCTAssertTrue(YES);\
+        } else {\
+            XCTFail("%@", errorDescription);\
+        }\
+    }
+
+#define SnapshotVerifyWithInvertedColorsAndTolerance(view__, identifier__, perPixelTolerance__, overallTolerance__)\
+    {\
+        _Pragma("clang diagnostic push")\
+        _Pragma("clang diagnostic ignored \"-Wundeclared-selector\"")\
+        SEL selector = @selector(snapshotVerifyWithInvertedColors:identifier:perPixelTolerance:overallTolerance:);\
+        _Pragma("clang diagnostic pop")\
+        typedef NSString * (*SnapshotMethod)(id, SEL, UIView *, NSString *, CGFloat, CGFloat);\
+        SnapshotMethod snapshotVerifyWithInvertedColors = (SnapshotMethod)[self methodForSelector:selector];\
+        NSString *errorDescription = snapshotVerifyWithInvertedColors(self, selector, view__, identifier__ ?: @"", perPixelTolerance__, overallTolerance__);\
         if (errorDescription == nil) {\
             XCTAssertTrue(YES);\
         } else {\


### PR DESCRIPTION
This PR adds the `precision` and `perPixelTolerance`/`overallTolerance` parameters to the different snapshot functions. (#63)