### PR TITLE
Remove XCTest as a dependency

### DIFF
--- a/AccessibilitySnapshot.podspec
+++ b/AccessibilitySnapshot.podspec
@@ -30,6 +30,8 @@ Pod::Spec.new do |s|
 
     ss.dependency 'AccessibilitySnapshot/Core'
     ss.dependency 'iOSSnapshotTestCase', '~> 6.0'
+    ss.frameworks = 'XCTest'
+    ss.weak_frameworks = 'XCTest'
   end
 
   s.subspec 'SnapshotTesting' do |ss|
@@ -37,8 +39,7 @@ Pod::Spec.new do |s|
 
     ss.dependency 'AccessibilitySnapshot/Core'
     ss.dependency 'SnapshotTesting', '~> 1.0'
+    ss.frameworks = 'XCTest'
+    ss.weak_frameworks = 'XCTest'
   end
-
-  s.frameworks = 'XCTest'
-  s.weak_frameworks = 'XCTest'
 end

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -38,7 +38,7 @@ CHECKOUT OPTIONS:
     :git: https://github.com/square/Paralayout
 
 SPEC CHECKSUMS:
-  AccessibilitySnapshot: 7d696575ee0df4371dde653b3087aaa9cfe4c300
+  AccessibilitySnapshot: 5f0c199c03bc3b007ffe5caf37fef2bba53831b4
   iOSSnapshotTestCase: 9ab44cb5aa62b84d31847f40680112e15ec579a6
   Paralayout: f4d6727fca5b592eb93a7cc408e45404599a4b0a
   SnapshotTesting: 8caa6661fea7c8019d5b46de77c16bab99c36c5c

--- a/Sources/AccessibilitySnapshot/Core/ObjC/ASAccessibilityEnabler.m
+++ b/Sources/AccessibilitySnapshot/Core/ObjC/ASAccessibilityEnabler.m
@@ -14,7 +14,7 @@
 //  limitations under the License.
 //
 
-#import <XCTest/XCTest.h>
+#import <Foundation/Foundation.h>
 #import <dlfcn.h>
 
 


### PR DESCRIPTION
## Description

Removes XCTest as a dependency of the Core library.

## Motivation and Context

I'm using AccessibilitySnapshot through [PlaybookAccessibilitySnapshot](https://github.com/playbook-ui/accessibility-snapshot-ios). (Thanks for mentioning my library in the README before 😄 ). 
Recently, the increase in testing time to get the snapshots has become an issue. So, since my project uses Bazel as a build system, I am challenging the effort to use a remote cache for the reference snapshots.
As a start, Bazel doesn't allow output from test runs as artifacts, so I need to output from the app simulator runtime instead of unit-test.
I've already taken care of this in Playbook, but I want to change it so that we can run without XCTest in this library as well because PlaybookAccessibilitySnapshot depends on this library.
Apparently, the Core library hasn't actually depended on XCTest, but since it was declared as a dependency, I removed it.