### PR TITLE
Bump Bundler dependencies

### DIFF
--- a/Example/Gemfile.lock
+++ b/Example/Gemfile.lock
@@ -1,14 +1,14 @@
 GIT
   remote: https://github.com/CocoaPods/CocoaPods
-  revision: 0a46d4948ae6a3fd9fee8c022741e2c36baca86d
+  revision: 6eef4a575324ab1447a5de5c768ca6096478f24a
   branch: master
   specs:
-    cocoapods (1.9.1)
-      activesupport (>= 4.0.2, < 5)
+    cocoapods (1.11.0.rc.1)
+      addressable (~> 2.8)
       claide (>= 1.0.2, < 2.0)
-      cocoapods-core (= 1.9.1)
+      cocoapods-core (= 1.11.0.rc.1)
       cocoapods-deintegrate (>= 1.0.3, < 2.0)
-      cocoapods-downloader (>= 1.2.2, < 2.0)
+      cocoapods-downloader (>= 1.4.0, < 2.0)
       cocoapods-plugins (>= 1.0.0, < 2.0)
       cocoapods-search (>= 1.0.0, < 2.0)
       cocoapods-trunk (>= 1.4.0, < 2.0)
@@ -17,97 +17,100 @@ GIT
       escape (~> 0.0.4)
       fourflusher (>= 2.3.0, < 3.0)
       gh_inspector (~> 1.0)
-      molinillo (~> 0.6.6)
+      molinillo (~> 0.8.0)
       nap (~> 1.0)
-      ruby-macho (~> 1.4)
-      xcodeproj (>= 1.14.0, < 2.0)
+      ruby-macho (>= 1.0, < 3.0)
+      xcodeproj (>= 1.21.0, < 2.0)
 
 GIT
   remote: https://github.com/CocoaPods/Core
-  revision: 01e301e2a30a312247252f0c155ec6b244f35c51
+  revision: 97f80f322e0e62b88d14ac35d7c66c6308fa61c5
   specs:
-    cocoapods-core (1.9.1)
-      activesupport (>= 4.0.2, < 6)
-      addressable (~> 2.6)
+    cocoapods-core (1.11.0.rc.1)
+      activesupport (>= 5.0, < 7)
+      addressable (~> 2.8)
       algoliasearch (~> 1.0)
       concurrent-ruby (~> 1.1)
       fuzzy_match (~> 2.0.4)
       nap (~> 1.0)
       netrc (~> 0.11)
-      public_suffix (~> 2.0)
+      public_suffix (~> 4.0)
       typhoeus (~> 1.0)
 
 GIT
   remote: https://github.com/CocoaPods/Molinillo
-  revision: d959b112a883c5c48a2e8b825368a449646a1e33
+  revision: 37613399f7be0c0a6f51d1bcb9702e4e2a8dff10
   specs:
-    molinillo (0.6.6)
+    molinillo (0.8.0)
 
 GIT
   remote: https://github.com/CocoaPods/Nanaimo
-  revision: 1414d9c0b642e376873138325f8132e8f053988a
+  revision: 1bf2e6e8781045fed99ca7020d5007234e715dc8
   specs:
-    nanaimo (0.2.6)
+    nanaimo (0.3.0)
 
 GIT
   remote: https://github.com/CocoaPods/Xcodeproj
-  revision: 1112f447897c116cac1a107de1ffbcb177c702f4
+  revision: 6b9db609dbda4bdac339c33ca23efa9c30a88e0e
   specs:
-    xcodeproj (1.16.0)
+    xcodeproj (1.21.0)
       CFPropertyList (>= 2.3.3, < 4.0)
       atomos (~> 0.1.3)
       claide (>= 1.0.2, < 2.0)
       colored2 (~> 3.1)
-      nanaimo (~> 0.2.6)
+      nanaimo (~> 0.3.0)
+      rexml (~> 3.2.4)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    CFPropertyList (3.0.2)
-    activesupport (4.2.11.3)
-      i18n (~> 0.7)
-      minitest (~> 5.1)
-      thread_safe (~> 0.3, >= 0.3.4)
-      tzinfo (~> 1.1)
-    addressable (2.7.0)
+    CFPropertyList (3.0.3)
+    activesupport (6.1.4.1)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 1.6, < 2)
+      minitest (>= 5.1)
+      tzinfo (~> 2.0)
+      zeitwerk (~> 2.3)
+    addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
-    algoliasearch (1.27.2)
+    algoliasearch (1.27.5)
       httpclient (~> 2.8, >= 2.8.3)
       json (>= 1.5.1)
     atomos (0.1.3)
     claide (1.0.3)
-    cocoapods-deintegrate (1.0.4)
-    cocoapods-downloader (1.3.0)
+    cocoapods-deintegrate (1.0.5)
+    cocoapods-downloader (1.4.0)
     cocoapods-plugins (1.0.0)
       nap
-    cocoapods-search (1.0.0)
+    cocoapods-search (1.0.1)
     cocoapods-trunk (1.5.0)
       nap (>= 0.8, < 2.0)
       netrc (~> 0.11)
     cocoapods-try (1.2.0)
     colored2 (3.1.2)
-    concurrent-ruby (1.1.6)
+    concurrent-ruby (1.1.9)
     escape (0.0.4)
-    ethon (0.12.0)
-      ffi (>= 1.3.0)
-    ffi (1.12.2)
+    ethon (0.14.0)
+      ffi (>= 1.15.0)
+    ffi (1.15.3)
     fourflusher (2.3.1)
     fuzzy_match (2.0.4)
     gh_inspector (1.1.3)
     httpclient (2.8.3)
-    i18n (0.9.5)
+    i18n (1.8.10)
       concurrent-ruby (~> 1.0)
-    json (2.3.0)
-    minitest (5.14.1)
+    json (2.5.1)
+    minitest (5.14.4)
     nap (1.1.0)
     netrc (0.11.0)
-    public_suffix (2.0.5)
-    ruby-macho (1.4.0)
-    thread_safe (0.3.6)
+    public_suffix (4.0.6)
+    rexml (3.2.5)
+    ruby-macho (2.5.1)
     typhoeus (1.4.0)
       ethon (>= 0.9.0)
-    tzinfo (1.2.7)
-      thread_safe (~> 0.1)
+    tzinfo (2.0.4)
+      concurrent-ruby (~> 1.0)
+    zeitwerk (2.4.2)
 
 PLATFORMS
   ruby


### PR DESCRIPTION
This resolves the `addressable` security vulnerability raised in #68 