### PR TITLE
Specify void argument type for UIAccessibilityAlwaysEnabled

### DIFF
--- a/Sources/AccessibilitySnapshot/Core/ObjC/UIAccessibilityStatusUtility.m
+++ b/Sources/AccessibilitySnapshot/Core/ObjC/UIAccessibilityStatusUtility.m
@@ -105,7 +105,7 @@ int rebind_symbols(struct rebinding rebindings[], size_t rebindings_nel);
     [self.rerebindings removeAllObjects];
 }
 
-BOOL UIAccessibilityAlwaysEnabled() {
+BOOL UIAccessibilityAlwaysEnabled(void) {
     return true;
 }
 


### PR DESCRIPTION
This resolves the `this old-style function definition is not preceded by a prototype [-Wstrict-prototypes]` warning.