### PR TITLE
Translate strings to Russian

### DIFF
--- a/Sources/AccessibilitySnapshot/Core/Swift/Assets/ru.lproj/Localizable.strings
+++ b/Sources/AccessibilitySnapshot/Core/Swift/Assets/ru.lproj/Localizable.strings
@@ -1,0 +1,80 @@
+/* Description for the 'selected' accessibility trait */
+"trait.selected.description" = "Выбрано.";
+
+/* Format for the description of the selected element; param0: the description of the element */
+"trait.selected.format" = "Выбрано: %@";
+
+/* Description for the 'not enabled' accessibility trait */
+"trait.not_enabled.description" = "Недоступно.";
+
+/* Description for the 'button' accessibility trait */
+"trait.button.description" = "Кнопка.";
+
+/* Description for the 'tab' accessibility trait */
+"trait.tab.description" = "Вкладка.";
+
+/* Description for the 'header' accessibility trait */
+"trait.header.description" = "Заголовок.";
+
+/* Description for the 'link' accessibility trait */
+"trait.link.description" = "Ссылка.";
+
+/* Description for the 'adjustable' accessibility trait */
+"trait.adjustable.description" = "Элемент ругулировки.";
+
+/* Hint describing how to use elements with the 'adjustable' accessibility trait */
+"trait.adjustable.hint" = "Смахните вверх или вниз одним пальцем, чтобы настроить значение.";
+
+/* Format for hint describing how to use elements with the 'adjustable' accessibility trait; param0: the existing hint */
+"trait.adjustable.hint_format" = "%@. Смахните вверх или вниз одним пальцем, чтобы настроить значение.";
+
+/* Description for the 'image' accessibility trait */
+"trait.image.description" = "Изображение.";
+
+/* Description for the 'search field' accessibility trait */
+"trait.search_field.description" = "Поле поиска.";
+
+/* Description for the 'switch button' accessibility trait, when the switch is on */
+"trait.switch_button.state_on.description" = "Кнопка-переключатель. Вкл.";
+
+/* Description for the 'switch button' accessibility trait, when the switch is off */
+"trait.switch_button.state_off.description" = "Кнопка-переключатель. Выкл.";
+
+/* Description for the 'switch button' accessibility trait, when the state of the switch cannot be determined */
+"trait.switch_button.state_unspecified.description" = "Кнопка-переключатель.";
+
+/* Hint describing how to use elements with the 'switch button' accessibility trait */
+"trait.switch_button.hint" = "Коснитесь дважды, чтобы переключить настройку.";
+
+/* Format for hint describing how to use elements with the 'switch button' accessibility trait; param0: the existing hint */
+"trait.switch_button.hint_format" = "%@. Коснитесь дважды, чтобы переключить настройку.";
+
+/* Format for the description of an element in a series; param0: the description of the element, param1: the index of the element in the series, param2: the number of elements in the series */
+"context.series.description_format" = "%1$@ %2$@ из %3$@.";
+
+/* Format for the description of the height of a cell in a table; param0: the number of rows the cell spans */
+"context.data_table.row_span_format" = "Охватывает %@ рядов.";
+
+/* Format for the description of the width of a cell in a table; param0: the number of columns the cell spans */
+"context.data_table.column_span_format" = "Охватывает %@ столбцов.";
+
+/* Format for the description of the vertical location of a cell in a table; param0: the row in which the cell resides */
+"context.data_table.row_format" = "Ряд %@.";
+
+/* Format for the description of the horizontal location of a cell in a table; param0: the column in which the cell resides */
+"context.data_table.column_format" = "Столбец %@.";
+
+/* Description of the first element in a list */
+"context.list_start.description" = "Начало списка.";
+
+/* Description of the last element in a list */
+"context.list_end.description" = "Конец списка.";
+
+/* Description of the first element in a landmark container */
+"context.landmark_start.description" = "Ориентир.";
+
+/* Description of the last element in a landmark container */
+"context.landmark_end.description" = "Конец строки.";
+
+/* Description for an accessibility element indicating that it has custom actions available */
+"custom_actions.description" = "Доступны действия";


### PR DESCRIPTION
We are going to use the library in our application and would like to translate text to Russian.

I have two questions:
- In which application I can see example of table's height that pronounce "Span 3 rows"
- Can I create [.strignsdic](https://developer.apple.com/library/archive/documentation/MacOSX/Conceptual/BPInternational/StringsdictFileFormat/StringsdictFileFormat.html)t to translate plurals correctly? In this case I need help with German translation