### PR TITLE
Handle -[UIApplication keyWindow] deprecation

### DIFF
--- a/Sources/AccessibilitySnapshot/SnapshotTesting/SnapshotTesting+Accessibility.swift
+++ b/Sources/AccessibilitySnapshot/SnapshotTesting/SnapshotTesting+Accessibility.swift
@@ -122,7 +122,18 @@ extension Snapshotting where Value == UIView, Format == UIImage {
             let requiresWindow = (view.window == nil && !(view is UIWindow))
 
             if requiresWindow {
-                let window = UIApplication.shared.keyWindow ?? UIWindow(frame: UIScreen.main.bounds)
+                let keyWindow: UIWindow? = {
+                    if #available(iOS 13.0, *) {
+                        return UIApplication
+                            .shared
+                            .connectedScenes
+                            .flatMap { ($0 as? UIWindowScene)?.windows ?? [] }
+                            .first { $0.isKeyWindow }
+                    } else {
+                        return UIApplication.shared.keyWindow
+                    }
+                }()
+                let window = keyWindow ?? UIWindow(frame: UIScreen.main.bounds)
                 window.addSubview(view)
             }
 

--- a/Sources/AccessibilitySnapshot/iOSSnapshotTestCase/FBSnapshotTestCase+Accessibility.swift
+++ b/Sources/AccessibilitySnapshot/iOSSnapshotTestCase/FBSnapshotTestCase+Accessibility.swift
@@ -168,7 +168,18 @@ extension FBSnapshotTestCase {
 
         let requiresWindow = (view.window == nil && !(view is UIWindow))
         if requiresWindow {
-            let window = UIApplication.shared.keyWindow ?? UIWindow(frame: UIScreen.main.bounds)
+            let keyWindow: UIWindow? = {
+                if #available(iOS 13.0, *) {
+                    return UIApplication
+                        .shared
+                        .connectedScenes
+                        .flatMap { ($0 as? UIWindowScene)?.windows ?? [] }
+                        .first { $0.isKeyWindow }
+                } else {
+                    return UIApplication.shared.keyWindow
+                }
+            }()
+            let window = keyWindow ?? UIWindow(frame: UIScreen.main.bounds)
             window.addSubview(view)
         }
 

--- a/Sources/AccessibilitySnapshot/iOSSnapshotTestCase/FBSnapshotTestCase+ObjCSupport.swift
+++ b/Sources/AccessibilitySnapshot/iOSSnapshotTestCase/FBSnapshotTestCase+ObjCSupport.swift
@@ -15,6 +15,7 @@
 //
 
 import FBSnapshotTestCase
+import UIKit
 
 extension FBSnapshotTestCase {
 
@@ -95,7 +96,18 @@ extension FBSnapshotTestCase {
 
         let requiresWindow = (view.window == nil && !(view is UIWindow))
         if requiresWindow {
-            let window = UIApplication.shared.keyWindow ?? UIWindow(frame: UIScreen.main.bounds)
+            let keyWindow: UIWindow? = {
+                if #available(iOS 13.0, *) {
+                    return UIApplication
+                        .shared
+                        .connectedScenes
+                        .flatMap { ($0 as? UIWindowScene)?.windows ?? [] }
+                        .first { $0.isKeyWindow }
+                } else {
+                    return UIApplication.shared.keyWindow
+                }
+            }()
+            let window = keyWindow ?? UIWindow(frame: UIScreen.main.bounds)
             window.addSubview(view)
         }
 


### PR DESCRIPTION
This was deprecated on iOS 13. It’s not currently a warning because the library’s deployment target is iOS 12, but it’ll be soon - plus it can be a warning if integrating the library via submodule or using the source code directly.
