### PR TITLE
Bump SPM deployment target to iOS 13

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -7,7 +7,7 @@ let package = Package(
     name: "AccessibilitySnapshot",
     defaultLocalization: "en",
     platforms: [
-        .iOS(.v12),
+        .iOS(.v13),
     ],
     products: [
         // Core + SnapshotTesting for image comparison


### PR DESCRIPTION
This change closes #105.

I have not updated the CocoaPods specification as SnapshotTesting has dropped support for it. Rather than removing support for CocoaPods from this library, I have opted to simply not include the new update there. This means CocoaPod users will not be able to update to v1.10.0, but can at least continue to use the last functioning version. A separate conversation may be worth having around keeping CocoaPods support going on as the general community is heading in a direction without it.

This is a breaking change for SPM users, as it does drop support for iOS 12 inline with the changes upstream. Again, this does not impact CocoaPod users.