### PR TITLE
Update to latest GitHub Actions first-party actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Bundle Install
         run: bundle install --gemfile=Example/Gemfile
       - name: Select Xcode Version (12.2)
@@ -29,7 +29,7 @@ jobs:
       - name: Build and Test
         run: Scripts/build.swift xcode ${{ matrix.platform }} `which xcpretty`
       - name: Upload Results
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: failure()
         with:
           name: Test Results
@@ -39,7 +39,7 @@ jobs:
     runs-on: macOS-10.15
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Bundle Install
         run: bundle install --gemfile=Example/Gemfile
       - name: Pod Install
@@ -55,7 +55,7 @@ jobs:
       fail-fast: false
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Select Xcode Version
         run: sudo xcode-select --switch /Applications/Xcode_12.2.app/Contents/Developer
       - name: Build


### PR DESCRIPTION
As a part of https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/, old versions of actions which relied on NodeJS 12 are deprecated.

This bumps both first-party ones to the lates version.