### PR TITLE
Move documentation from Wiki into Documentation folder

### DIFF
--- a/Documentation/Core-Architecture.md
+++ b/Documentation/Core-Architecture.md
@@ -1,0 +1,17 @@
+The core accessibility parsing and presentation logic lives in the `Core` subspec. In most cases, consumers will interact with an integration layer built on top of the core parser that performs the actual snapshot recording and comparison. The following are the primary classes in the public API of the core parser with which the integration layer will interact.
+
+* `AnimationSnapshotView` - This is a container view around the view being snapshotted. It contains a snapshot of the view and the views that make up the highlights and legend.
+
+The `AnimationSnapshotView` is the only class the integration layer needs to interact with to output snapshot images of the accessibility hierarchy. For non-view-based integrations, the `AccessibilityHierarchyParser` is the main integration point.
+
+* `AccessibilityHierarchyParser` - This is where all of the parsing logic lives. It has a single exposed method that returns an array of accessibility markers.
+
+* `ASAccessibilityEnabler` - This class enabled accessibility on the simulator. The logic in this class is triggered in the `+load` method, so there shouldn't generally be work in the integration layer to activate it. If the logic in this class isn't run, many of the accessibility properties won't be automatically populated by UIKit, resulting in missing data.
+
+In addition to the accessibility hierarchy parsing logic, the `Core` subspec also contains a few points of interaction for snapshotting with inverted colors and (the currently in-progress #4) dynamic type:
+
+* `UIAccessibilityStatusUtility` - This is used to mock the Invert Colors setting.
+
+* `UIView.drawHierarchyWithInvertedColors(in:using:)` - This extension does the actual drawing.
+
+* `UIView+DynamicTypeSnapshotting`/`UIApplication+DynamicTypeSnapshotting` - These are used to mock the Dynamic Type setting.

--- a/Documentation/README.md
+++ b/Documentation/README.md
@@ -1,0 +1,7 @@
+AccessibilitySnapshot is split into two main layers: the core accessibility parser and an integration layer using a snapshotting engine. This is reflected in the pod's two subspecs: `Core` and `iOSSnapshotTestCase`.
+
+The `Core` subspec contains the accessibility parser and utilities for generating a container view to snapshot that includes a legend showing each of the accessibility elements in the view. The [Core Architecture](Core-Architecture.md) page contains more details on the different components that make up this subspec.
+
+The `iOSSnapshotTestCase` subspec contains an integration layer built on top of the parser that provides simple snapshotting via the iOSSnapshotTestCase framework. Instructions for getting started with this can be found in the [Usage](https://github.com/cashapp/AccessibilitySnapshot/blob/master/README.md#usage) section of the README.
+
+Alternative integration layers can be built on top of the core parser by depending only on the `Core` subspec. A list of these can be found in the [Extensions](https://github.com/cashapp/AccessibilitySnapshot/blob/master/README.md#extensions) section of the README.

--- a/Documentation/README.md
+++ b/Documentation/README.md
@@ -1,7 +1,7 @@
-AccessibilitySnapshot is split into two main layers: the core accessibility parser and an integration layer using a snapshotting engine. This is reflected in the pod's two subspecs: `Core` and `iOSSnapshotTestCase`.
+AccessibilitySnapshot is split into two layers: the core accessibility parser and an integration layer using a snapshotting engine. This is reflected in the pod's three subspecs: the `Core` subspec for the accessibility parser, and the `iOSSnapshotTestCase` and `SnapshotTesting` subspecs for the two available integration layers.
 
 The `Core` subspec contains the accessibility parser and utilities for generating a container view to snapshot that includes a legend showing each of the accessibility elements in the view. The [Core Architecture](Core-Architecture.md) page contains more details on the different components that make up this subspec.
 
-The `iOSSnapshotTestCase` subspec contains an integration layer built on top of the parser that provides simple snapshotting via the iOSSnapshotTestCase framework. Instructions for getting started with this can be found in the [Usage](https://github.com/cashapp/AccessibilitySnapshot/blob/master/README.md#usage) section of the README.
+The other two subspecs contain integration layers built on top of the parser that provide simple snapshotting via the iOSSnapshotTestCase and SnapshotTesting framework, respectively. Instructions for getting started with these can be found in the [Usage](https://github.com/cashapp/AccessibilitySnapshot/blob/master/README.md#usage) section of the README.
 
 Alternative integration layers can be built on top of the core parser by depending only on the `Core` subspec. A list of these can be found in the [Extensions](https://github.com/cashapp/AccessibilitySnapshot/blob/master/README.md#extensions) section of the README.


### PR DESCRIPTION
Currently documentation for the repo is stored in the [Wiki](https://github.com/cashapp/AccessibilitySnapshot/wiki). But this isn't super discoverable (wikis don't seem to be that popular), can easily get out-of-sync with the code, and isn't available offline when you clone the repo. To try to improve this, I think we should move the documentation into the repo.