### PR TITLE
Handle nil user input labels

### DIFF
--- a/Sources/AccessibilitySnapshot/Core/Swift/Classes/AccessibilityHierarchyParser.swift
+++ b/Sources/AccessibilitySnapshot/Core/Swift/Classes/AccessibilityHierarchyParser.swift
@@ -190,8 +190,15 @@ public final class AccessibilityHierarchyParser {
             let (description, hint) = element.object.accessibilityDescription(context: element.context)
             
             let userInputLabels: [String]? = {
-                guard element.object.accessibilityRespondsToUserInteraction, element.object.accessibilityUserInputLabels.count > 0 else { return nil }
-                return element.object.accessibilityUserInputLabels
+                guard
+                    element.object.accessibilityRespondsToUserInteraction,
+                    let userInputLabels = element.object.accessibilityUserInputLabels,
+                    !userInputLabels.isEmpty
+                else {
+                    return nil
+                }
+
+                return userInputLabels
             }()
 
             let activationPoint = element.object.accessibilityActivationPoint


### PR DESCRIPTION
The `accessibilityUserInputLabels` property is an implicitly-unwrapped optional (`[String]!`). This wasn't causing any issues in our current test suite, but in iOS 16 SwiftUI returns `nil` for the user input labels, which revealed this crash.