### PR TITLE
Add preset configuration sets for ElementSelectionViewController

### DIFF
--- a/Example/AccessibilitySnapshot/ElementSelectionViewController.swift
+++ b/Example/AccessibilitySnapshot/ElementSelectionViewController.swift
@@ -107,10 +107,74 @@ extension ElementSelectionViewController {
     static func makeConfigurationSelectionViewController(
         presentingViewController: UIViewController
     ) -> UIViewController {
-        return makeAlertControllerForElementSelection(
-            presentingViewController: presentingViewController,
-            existingConfigurations: []
+        func selectConfigurations(_ configurations: [ElementSelectionViewController.ViewConfiguration]) {
+            let elementSelectionViewController = ElementSelectionViewController(configurations: configurations)
+            elementSelectionViewController.modalPresentationStyle = .fullScreen
+            presentingViewController.present(elementSelectionViewController, animated: true, completion: nil)
+        }
+
+        let alertController = UIAlertController(
+            title: nil,
+            message: nil,
+            preferredStyle: .actionSheet
         )
+
+        alertController.addAction(.init(title: "Two Accessibility Elements", style: .default) { _ in
+            selectConfigurations(.twoAccessibilityElements)
+        })
+
+        alertController.addAction(.init(title: "Accessibility Element with Elements Hidden", style: .default) { _ in
+            selectConfigurations(.accessibilityElementWithElementsHidden)
+        })
+
+        alertController.addAction(.init(title: "Accessibility Element Hidden", style: .default) { _ in
+            selectConfigurations(.accessibilityElementHidden)
+        })
+
+        alertController.addAction(.init(title: "No Accessibility Elements", style: .default) { _ in
+            selectConfigurations(.noAccessibilityElements)
+        })
+
+        alertController.addAction(.init(title: "Mixed Accessibility Elements", style: .default) { _ in
+            selectConfigurations(.mixedAccessibilityElements)
+        })
+
+        alertController.addAction(.init(title: "Accessibility Container", style: .default) { _ in
+            selectConfigurations(.accessibilityContainer)
+        })
+
+        alertController.addAction(.init(title: "Accessibility Container With Elements Hidden", style: .default) { _ in
+            selectConfigurations(.accessibilityContainerWithElementsHidden)
+        })
+
+        alertController.addAction(.init(title: "Accessibility Container Hidden", style: .default) { _ in
+            selectConfigurations(.accessibilityContainerHidden)
+        })
+
+        alertController.addAction(.init(title: "Grouped Views", style: .default) { _ in
+            selectConfigurations(.groupedViews)
+        })
+
+        alertController.addAction(.init(title: "Grouped Views In Parent That Hides Elements", style: .default) { _ in
+            selectConfigurations(.groupedViewsInParentThatHidesElements)
+        })
+
+        alertController.addAction(.init(title: "Grouped Views In Hidden Parent", style: .default) { _ in
+            selectConfigurations(.groupedViewsInHiddenParent)
+        })
+
+        alertController.addAction(.init(title: "Custom", style: .default, handler: { _ in
+            presentingViewController.present(
+                makeAlertControllerForElementSelection(
+                    presentingViewController: presentingViewController,
+                    existingConfigurations: []
+                ),
+                animated: true,
+                completion: nil
+            )
+        }))
+
+        return alertController
     }
 
     private static func makeAlertControllerForElementSelection(
@@ -193,6 +257,90 @@ extension ElementSelectionViewController {
         }
 
         return alertController
+    }
+
+}
+
+// MARK: -
+
+extension Array where Element == ElementSelectionViewController.ViewConfiguration {
+
+    static var twoAccessibilityElements: [Element] {
+        return [
+            .accessibilityElement(accessibilityElementsHidden: false, isHidden: false),
+            .accessibilityElement(accessibilityElementsHidden: false, isHidden: false),
+        ]
+    }
+
+    static var accessibilityElementWithElementsHidden: [Element] {
+        return [
+            .accessibilityElement(accessibilityElementsHidden: false, isHidden: false),
+            .accessibilityElement(accessibilityElementsHidden: true, isHidden: false),
+        ]
+    }
+
+    static var accessibilityElementHidden: [Element] {
+        return [
+            .accessibilityElement(accessibilityElementsHidden: false, isHidden: false),
+            .accessibilityElement(accessibilityElementsHidden: false, isHidden: true),
+        ]
+    }
+
+    static var noAccessibilityElements: [Element] {
+        return [
+            .nonAccessibilityElement,
+            .nonAccessibilityElement,
+        ]
+    }
+
+    static var mixedAccessibilityElements: [Element] {
+        return [
+            .accessibilityElement(accessibilityElementsHidden: false, isHidden: false),
+            .nonAccessibilityElement,
+            .accessibilityElement(accessibilityElementsHidden: false, isHidden: false),
+            .nonAccessibilityElement,
+        ]
+    }
+
+    static var accessibilityContainer: [Element] {
+        return [
+            .accessibilityContainer(accessibilityElementsHidden: false, isHidden: false),
+        ]
+    }
+
+    static var accessibilityContainerWithElementsHidden: [Element] {
+        return [
+            .accessibilityElement(accessibilityElementsHidden: false, isHidden: false),
+            .accessibilityContainer(accessibilityElementsHidden: true, isHidden: false),
+        ]
+    }
+
+    static var accessibilityContainerHidden: [Element] {
+        return [
+            .accessibilityElement(accessibilityElementsHidden: false, isHidden: false),
+            .accessibilityContainer(accessibilityElementsHidden: false, isHidden: true),
+        ]
+    }
+
+    static var groupedViews: [Element] {
+        return [
+            .accessibilityElement(accessibilityElementsHidden: false, isHidden: false),
+            .viewWithAccessibleSubviews(accessibilityElementsHidden: false, isHidden: false),
+        ]
+    }
+
+    static var groupedViewsInParentThatHidesElements: [Element] {
+        return [
+            .accessibilityElement(accessibilityElementsHidden: false, isHidden: false),
+            .viewWithAccessibleSubviews(accessibilityElementsHidden: true, isHidden: false),
+        ]
+    }
+
+    static var groupedViewsInHiddenParent: [Element] {
+        return [
+            .accessibilityElement(accessibilityElementsHidden: false, isHidden: false),
+            .viewWithAccessibleSubviews(accessibilityElementsHidden: false, isHidden: true),
+        ]
     }
 
 }

--- a/Example/SnapshotTests/ElementSelectionTests.swift
+++ b/Example/SnapshotTests/ElementSelectionTests.swift
@@ -22,101 +22,89 @@ import FBSnapshotTestCase
 final class ElementSelectionTests: SnapshotTestCase {
 
     func testTwoAccessibilityElements() {
-        let elementSelectionViewController = ElementSelectionViewController(configurations: [
-            .accessibilityElement(accessibilityElementsHidden: false, isHidden: false),
-            .accessibilityElement(accessibilityElementsHidden: false, isHidden: false),
-        ])
+        let elementSelectionViewController = ElementSelectionViewController(
+            configurations: .twoAccessibilityElements
+        )
         elementSelectionViewController.view.frame = UIScreen.main.bounds
         SnapshotVerifyAccessibility(elementSelectionViewController.view)
     }
 
     func testAccessibilityElementWithElementsHidden() {
-        let elementSelectionViewController = ElementSelectionViewController(configurations: [
-            .accessibilityElement(accessibilityElementsHidden: false, isHidden: false),
-            .accessibilityElement(accessibilityElementsHidden: true, isHidden: false),
-        ])
+        let elementSelectionViewController = ElementSelectionViewController(
+            configurations: .accessibilityElementWithElementsHidden
+        )
         elementSelectionViewController.view.frame = UIScreen.main.bounds
         SnapshotVerifyAccessibility(elementSelectionViewController.view)
     }
 
     func testAccessibilityElementHidden() {
-        let elementSelectionViewController = ElementSelectionViewController(configurations: [
-            .accessibilityElement(accessibilityElementsHidden: false, isHidden: false),
-            .accessibilityElement(accessibilityElementsHidden: false, isHidden: true),
-        ])
+        let elementSelectionViewController = ElementSelectionViewController(
+            configurations: .accessibilityElementHidden
+        )
         elementSelectionViewController.view.frame = UIScreen.main.bounds
         SnapshotVerifyAccessibility(elementSelectionViewController.view)
     }
 
     func testNoAccessibilityElements() {
-        let elementSelectionViewController = ElementSelectionViewController(configurations: [
-            .nonAccessibilityElement,
-            .nonAccessibilityElement,
-        ])
+        let elementSelectionViewController = ElementSelectionViewController(
+            configurations: .noAccessibilityElements
+        )
         elementSelectionViewController.view.frame = UIScreen.main.bounds
         SnapshotVerifyAccessibility(elementSelectionViewController.view)
     }
 
     func testMixedAccessibilityElements() {
-        let elementSelectionViewController = ElementSelectionViewController(configurations: [
-            .accessibilityElement(accessibilityElementsHidden: false, isHidden: false),
-            .nonAccessibilityElement,
-            .accessibilityElement(accessibilityElementsHidden: false, isHidden: false),
-            .nonAccessibilityElement,
-        ])
+        let elementSelectionViewController = ElementSelectionViewController(
+            configurations: .mixedAccessibilityElements
+        )
         elementSelectionViewController.view.frame = UIScreen.main.bounds
         SnapshotVerifyAccessibility(elementSelectionViewController.view)
     }
 
     func testAccessibilityContainer() {
-        let elementSelectionViewController = ElementSelectionViewController(configurations: [
-            .accessibilityContainer(accessibilityElementsHidden: false, isHidden: false),
-        ])
+        let elementSelectionViewController = ElementSelectionViewController(
+            configurations: .accessibilityContainer
+        )
         elementSelectionViewController.view.frame = UIScreen.main.bounds
         SnapshotVerifyAccessibility(elementSelectionViewController.view)
     }
 
     func testAccessibilityContainerWithElementsHidden() {
-        let elementSelectionViewController = ElementSelectionViewController(configurations: [
-            .accessibilityElement(accessibilityElementsHidden: false, isHidden: false),
-            .accessibilityContainer(accessibilityElementsHidden: true, isHidden: false),
-        ])
+        let elementSelectionViewController = ElementSelectionViewController(
+            configurations: .accessibilityContainerWithElementsHidden
+        )
         elementSelectionViewController.view.frame = UIScreen.main.bounds
         SnapshotVerifyAccessibility(elementSelectionViewController.view)
     }
 
     func testAccessibilityContainerHidden() {
-        let elementSelectionViewController = ElementSelectionViewController(configurations: [
-            .accessibilityElement(accessibilityElementsHidden: false, isHidden: false),
-            .accessibilityContainer(accessibilityElementsHidden: false, isHidden: true),
-        ])
+        let elementSelectionViewController = ElementSelectionViewController(
+            configurations: .accessibilityContainerHidden
+        )
         elementSelectionViewController.view.frame = UIScreen.main.bounds
         SnapshotVerifyAccessibility(elementSelectionViewController.view)
     }
 
     func testGroupedViews() {
-        let elementSelectionViewController = ElementSelectionViewController(configurations: [
-            .accessibilityElement(accessibilityElementsHidden: false, isHidden: false),
-            .viewWithAccessibleSubviews(accessibilityElementsHidden: false, isHidden: false),
-        ])
+        let elementSelectionViewController = ElementSelectionViewController(
+            configurations: .groupedViews
+        )
         elementSelectionViewController.view.frame = UIScreen.main.bounds
         SnapshotVerifyAccessibility(elementSelectionViewController.view)
     }
 
     func testGroupedViewsInParentThatHidesElements() {
-        let elementSelectionViewController = ElementSelectionViewController(configurations: [
-            .accessibilityElement(accessibilityElementsHidden: false, isHidden: false),
-            .viewWithAccessibleSubviews(accessibilityElementsHidden: true, isHidden: false),
-        ])
+        let elementSelectionViewController = ElementSelectionViewController(
+            configurations: .groupedViewsInParentThatHidesElements
+        )
         elementSelectionViewController.view.frame = UIScreen.main.bounds
         SnapshotVerifyAccessibility(elementSelectionViewController.view)
     }
 
     func testGroupedViewsInHiddenParent() {
-        let elementSelectionViewController = ElementSelectionViewController(configurations: [
-            .accessibilityElement(accessibilityElementsHidden: false, isHidden: false),
-            .viewWithAccessibleSubviews(accessibilityElementsHidden: false, isHidden: true),
-        ])
+        let elementSelectionViewController = ElementSelectionViewController(
+            configurations: .groupedViewsInHiddenParent
+        )
         elementSelectionViewController.view.frame = UIScreen.main.bounds
         SnapshotVerifyAccessibility(elementSelectionViewController.view)
     }


### PR DESCRIPTION
This makes it easier to synchronize configurations between the demo app and the snapshot tests, which is very useful in auditing new iOS versions. Resolves #161.