### PR TITLE
Adding AXCustomContent support

### DIFF
--- a/Example/AccessibilitySnapshot.xcodeproj/project.pbxproj
+++ b/Example/AccessibilitySnapshot.xcodeproj/project.pbxproj
@@ -54,6 +54,7 @@
 		66E2CD14CD63946657E17B15 /* Pods_SnapshotTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3A3192D7B9B16BD10FB517A2 /* Pods_SnapshotTests.framework */; };
 		83A295842AC22D9D00DFBE4F /* UserInputLabelsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83A295832AC22D9D00DFBE4F /* UserInputLabelsViewController.swift */; };
 		83A295862AC22EEE00DFBE4F /* UserInputLabelsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83A295852AC22EEE00DFBE4F /* UserInputLabelsTests.swift */; };
+		AC725B842B06D07E009AD59B /* AccessibilityCustomContentViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC725B832B06D07E009AD59B /* AccessibilityCustomContentViewController.swift */; };
 		C47F6C5316FB0C043BEB59F3 /* Pods_AccessibilitySnapshotDemo.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6A886964D2E787399E137105 /* Pods_AccessibilitySnapshotDemo.framework */; };
 		D38F6F4E508A3D067D677F69 /* Pods_UnitTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0BFCB4FD6BC17AB232B26E72 /* Pods_UnitTests.framework */; };
 /* End PBXBuildFile section */
@@ -139,6 +140,7 @@
 		83A295832AC22D9D00DFBE4F /* UserInputLabelsViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserInputLabelsViewController.swift; sourceTree = "<group>"; };
 		83A295852AC22EEE00DFBE4F /* UserInputLabelsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserInputLabelsTests.swift; sourceTree = "<group>"; };
 		88C33CBF672C290CE1EE86AF /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; name = README.md; path = ../README.md; sourceTree = "<group>"; };
+		AC725B832B06D07E009AD59B /* AccessibilityCustomContentViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessibilityCustomContentViewController.swift; sourceTree = "<group>"; };
 		C78F90CE7A2A315AADF80144 /* Pods-SnapshotTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SnapshotTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-SnapshotTests/Pods-SnapshotTests.debug.xcconfig"; sourceTree = "<group>"; };
 		CCFF2A604706B71DC0CBD38B /* Pods-AccessibilitySnapshotDemo.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AccessibilitySnapshotDemo.release.xcconfig"; path = "Pods/Target Support Files/Pods-AccessibilitySnapshotDemo/Pods-AccessibilitySnapshotDemo.release.xcconfig"; sourceTree = "<group>"; };
 		DBA3D7413A13111BA7DE4750 /* Pods-UnitTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-UnitTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-UnitTests/Pods-UnitTests.release.xcconfig"; sourceTree = "<group>"; };
@@ -198,6 +200,7 @@
 				3DBAC2902242F9B200EF4D0A /* LandmarkContainerViewController.swift */,
 				3D3F2E132263E6B900F7608E /* InvertColorsViewController.swift */,
 				3DDE7FF524C6D6BF00999ABA /* AccessibilityCustomActionsViewController.swift */,
+				AC725B832B06D07E009AD59B /* AccessibilityCustomContentViewController.swift */,
 			);
 			name = "Accessibility Screens";
 			sourceTree = "<group>";
@@ -625,6 +628,7 @@
 				3DF46502220D7F9B0048D446 /* ElementOrderViewController.swift in Sources */,
 				3DDE7FF624C6D6BF00999ABA /* AccessibilityCustomActionsViewController.swift in Sources */,
 				3DBAC28F2242E7C700EF4D0A /* ListContainerViewController.swift in Sources */,
+				AC725B842B06D07E009AD59B /* AccessibilityCustomContentViewController.swift in Sources */,
 				3DBEAA5B2222953E00FAE61D /* SwitchControlViewController.swift in Sources */,
 				3DBAC2912242F9B200EF4D0A /* LandmarkContainerViewController.swift in Sources */,
 				3D39BFAC223314C1009C3EF4 /* TabBarViewController.swift in Sources */,

--- a/Example/AccessibilitySnapshot/AccessibilityCustomContentViewController.swift
+++ b/Example/AccessibilitySnapshot/AccessibilityCustomContentViewController.swift
@@ -1,0 +1,117 @@
+//
+//  Copyright 2020 Square Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Paralayout
+import UIKit
+
+@available(iOS 14.0, *)
+final class AccessibilityCustomContentViewController: AccessibilityViewController {
+
+    // MARK: - UIViewController
+
+    override func loadView() {
+        view = View(
+            views: [
+                .init(includeLabel: true, includeHint: true),
+                .init(includeLabel: true, includeHint: false),
+                .init(includeLabel: false, includeHint: true),
+                .init(includeLabel: false, includeHint: false),
+            ]
+        )
+    }
+
+}
+
+// MARK: -
+@available(iOS 14.0, *)
+private extension AccessibilityCustomContentViewController {
+
+    final class View: UIView {
+
+        // MARK: - Life Cycle
+
+        init(views: [CustomContentView], frame: CGRect = .zero) {
+            self.views = views
+
+            super.init(frame: frame)
+
+            views.forEach(addSubview)
+        }
+
+        @available(*, unavailable)
+        required init?(coder: NSCoder) {
+            fatalError("init(coder:) has not been implemented")
+        }
+
+        // MARK: - Private Properties
+
+        private let views: [CustomContentView]
+
+        // MARK: - UIView
+
+        override func layoutSubviews() {
+            views.forEach { $0.bounds.size = .init(width: bounds.width / 2, height: 50) }
+
+            let statusBarHeight = window?.windowScene?.statusBarManager?.statusBarFrame.height ?? 0
+
+            var distributionSpecifiers: [ViewDistributionSpecifying] = [ statusBarHeight.fixed, 1.flexible ]
+            for subview in views {
+                distributionSpecifiers.append(subview)
+                distributionSpecifiers.append(1.flexible)
+            }
+            applyVerticalSubviewDistribution(distributionSpecifiers)
+        }
+
+    }
+
+}
+
+// MARK: -
+@available(iOS 14.0, *)
+private extension AccessibilityCustomContentViewController {
+
+    final class CustomContentView: UIView, AXCustomContentProvider {
+        
+
+        // MARK: - Life Cycle
+
+        init(includeLabel: Bool, includeHint: Bool) {
+            super.init(frame: .zero)
+
+            backgroundColor = .gray
+
+            isAccessibilityElement = true
+
+            accessibilityLabel = includeLabel ? "Label" : nil
+            accessibilityHint = includeHint ? "Hint" : nil
+        }
+
+        @available(*, unavailable)
+        required init?(coder: NSCoder) {
+            fatalError("init(coder:) has not been implemented")
+        }
+
+        // MARK: - UIAccessibility
+        var accessibilityCustomContent: [AXCustomContent]! = {
+            let customContent = AXCustomContent(label: "Custom Content Label", value: "Custom Content Value")
+
+            let highImportance = AXCustomContent(label: "High Importance Label", value: "High Importance Value")
+            highImportance.importance = .high
+           
+            return [customContent, highImportance]
+        }()
+    }
+}

--- a/Example/AccessibilitySnapshot/RootViewController.swift
+++ b/Example/AccessibilitySnapshot/RootViewController.swift
@@ -52,6 +52,12 @@ final class RootViewController: UITableViewController {
             ("Accessibility Paths", { _ in return AccessibilityPathViewController() }),
             ("Accessibility Activation Point", { _ in return ActivationPointViewController() }),
             ("Accessibility Custom Actions", { _ in return AccessibilityCustomActionsViewController() }),
+            ("Accessibility Custom Content", {
+                if #available(iOS 14.0, *) {
+                    return AccessibilityCustomContentViewController()
+                } else {
+                    return $0
+                } }),
             ("Data Table", { presentingViewController in
                 return DataTableViewController.makeConfigurationSelectionViewController(
                     presentingViewController: presentingViewController
@@ -62,6 +68,7 @@ final class RootViewController: UITableViewController {
             ("Invert Colors", { _ in return InvertColorsViewController() }),
             ("User Input Labels", { _ in return UserInputLabelsViewController() }),
         ]
+        
 
         super.init(nibName: nil, bundle: nil)
     }

--- a/Example/AccessibilitySnapshot/SwiftUIView.swift
+++ b/Example/AccessibilitySnapshot/SwiftUIView.swift
@@ -77,6 +77,24 @@ struct SwiftUIView: View {
                 .accessibility(label: Text("Label"))
                 .accessibility(value: Text("Value"))
                 .accessibility(hint: Text("Hint"))
+            
+            if #available(iOS 14.0, *) {
+                // View with label, value, hint, and Custom Actions.
+                Circle()
+                    .accessibility(label: Text("Label"))
+                    .accessibility(value: Text("Value"))
+                    .accessibility(hint: Text("Hint"))
+                    .accessibilityAction(named: "Custom") {}
+            }
+            
+            if #available(iOS 15.0, *) {
+                // View with label, value, hint, and Custom Content.
+                Circle()
+                    .accessibility(label: Text("Label"))
+                    .accessibility(value: Text("Value"))
+                    .accessibility(hint: Text("Hint"))
+                    .accessibilityCustomContent("Key", "Value")
+            }
 
             Spacer()
         }

--- a/Example/SnapshotTests/AccessibilityPropertiesTests.swift
+++ b/Example/SnapshotTests/AccessibilityPropertiesTests.swift
@@ -69,6 +69,13 @@ final class AccessibilitySnapshotTests: SnapshotTestCase {
         customActionsViewController.view.frame = UIScreen.main.bounds
         SnapshotVerifyAccessibility(customActionsViewController.view)
     }
+    
+    @available(iOS 14.0, *)
+    func testCustomContent() {
+        let customContentViewController = AccessibilityCustomContentViewController()
+        customContentViewController.view.frame = UIScreen.main.bounds
+        SnapshotVerifyAccessibility(customContentViewController.view)
+    }
 
     func testLargeView() throws {
         let view = UIView(frame: CGRect(x: 0, y: 0, width: 1400, height: 1400))

--- a/Sources/AccessibilitySnapshot/Core/Swift/Classes/AccessibilityHierarchyParser.swift
+++ b/Sources/AccessibilitySnapshot/Core/Swift/Classes/AccessibilityHierarchyParser.swift
@@ -715,9 +715,11 @@ extension NSObject {
         if #available(iOS 14.0, *) {
             if let provider = self as? AXCustomContentProvider {
                 if #available(iOS 17.0, *) {
-                    if let customContentBlock = provider.accessibilityCustomContentBlock, let content = customContentBlock?() {
-                            return content.map { content in
-                                return (content.label, content.value, content.importance == .high)
+                    if let customContentBlock = provider.accessibilityCustomContentBlock {
+                            if let content = customContentBlock?() {
+                                return content.map { content in
+                                    return (content.label, content.value, content.importance == .high)
+                                }
                             }
                         }
                     }

--- a/Sources/AccessibilitySnapshot/Core/Swift/Classes/AccessibilityHierarchyParser.swift
+++ b/Sources/AccessibilitySnapshot/Core/Swift/Classes/AccessibilityHierarchyParser.swift
@@ -57,6 +57,9 @@ public struct AccessibilityMarker {
 
     /// The names of the custom actions supported by the element.
     public var customActions: [String]
+    
+    /// The names of the custom content included by the element.
+    public var customContent: [(label:String, value: String)]
 
     /// The language code of the language used to localize strings in the description.
     public var accessibilityLanguage: String?
@@ -211,6 +214,7 @@ public final class AccessibilityHierarchyParser {
                 activationPoint: root.convert(activationPoint, from: nil),
                 usesDefaultActivationPoint: (activationPoint == defaultActivationPoint(for: element.object)),
                 customActions: element.object.accessibilityCustomActions?.map { $0.name } ?? [],
+                customContent: element.object.customContent,
                 accessibilityLanguage: element.object.accessibilityLanguage
             )
         }
@@ -700,5 +704,30 @@ extension UIView {
         newPath.apply(transform)
         return newPath
     }
+    
 
+
+}
+
+
+extension NSObject {
+    var customContent: [(String, String)] {
+        if #available(iOS 14.0, *) {
+            if let provider = self as? AXCustomContentProvider {
+                if #available(iOS 17.0, *) {
+                    if let customContentBlock = provider.accessibilityCustomContentBlock, let content = customContentBlock?() {
+                            return content.map { content in
+                                return (content.label, content.value)
+                            }
+                        }
+                    }
+                
+                return provider.accessibilityCustomContent.map { content in
+                    return (content.label, content.value)
+                }
+            }
+        }
+        
+        return []
+    }
 }

--- a/Sources/AccessibilitySnapshot/Core/Swift/Classes/AccessibilityHierarchyParser.swift
+++ b/Sources/AccessibilitySnapshot/Core/Swift/Classes/AccessibilityHierarchyParser.swift
@@ -59,7 +59,7 @@ public struct AccessibilityMarker {
     public var customActions: [String]
     
     /// The names of the custom content included by the element.
-    public var customContent: [(label:String, value: String)]
+    public var customContent: [(label:String, value: String, isImportant:Bool)]
 
     /// The language code of the language used to localize strings in the description.
     public var accessibilityLanguage: String?
@@ -711,19 +711,19 @@ extension UIView {
 
 
 extension NSObject {
-    var customContent: [(String, String)] {
+    var customContent: [(label: String, value: String, isImportant:Bool)] {
         if #available(iOS 14.0, *) {
             if let provider = self as? AXCustomContentProvider {
                 if #available(iOS 17.0, *) {
                     if let customContentBlock = provider.accessibilityCustomContentBlock, let content = customContentBlock?() {
                             return content.map { content in
-                                return (content.label, content.value)
+                                return (content.label, content.value, content.importance == .high)
                             }
                         }
                     }
                 
                 return provider.accessibilityCustomContent.map { content in
-                    return (content.label, content.value)
+                    return (content.label, content.value, content.importance == .high)
                 }
             }
         }

--- a/Sources/AccessibilitySnapshot/Core/Swift/Classes/AccessibilitySnapshotView.swift
+++ b/Sources/AccessibilitySnapshot/Core/Swift/Classes/AccessibilitySnapshotView.swift
@@ -844,7 +844,10 @@ private final class CustomContentView: UIView {
             let customContentLabel = UILabel()
             customContentLabel.font = isImportant ? Metrics.boldFont : Metrics.font
             customContentLabel.numberOfLines = 0
-            customContentLabel.text = "\(label): \(value)"
+            customContentLabel.text = {
+                guard !value.isEmpty else { return label }
+                return "\(label): \(value)"
+            }()
             
             return (iconLabel, customContentLabel)
         }

--- a/Sources/AccessibilitySnapshot/Core/Swift/Classes/AccessibilitySnapshotView.swift
+++ b/Sources/AccessibilitySnapshot/Core/Swift/Classes/AccessibilitySnapshotView.swift
@@ -833,22 +833,18 @@ private final class CustomContentView: UIView {
 
     // MARK: - Life Cycle
     
-    init(customContentText: String?, customContent: [(String, String)]) {
+    init(customContentText: String?, customContent: [(String, String, Bool)]) {
         
-        contentLabels = customContent.map { content in
+        contentLabels = customContent.map { (label, value, isImportant) in
             let iconLabel = UILabel()
             iconLabel.text = "↓"
             iconLabel.font = Metrics.font
             iconLabel.numberOfLines = 0
             
             let customContentLabel = UILabel()
-            customContentLabel.font = Metrics.font
+            customContentLabel.font = isImportant ? Metrics.boldFont : Metrics.font
             customContentLabel.numberOfLines = 0
-            customContentLabel.text = {
-                let label = content.0
-                let value = content.1
-                return "\(label): \(value)"
-            }()
+            customContentLabel.text = "\(label): \(value)"
             
             return (iconLabel, customContentLabel)
         }
@@ -894,7 +890,7 @@ private final class CustomContentView: UIView {
         }
 
         let descriptionWidthToFit = [
-            Metrics.actionIconInset,
+            Metrics.contentIconInset,
             firstIconLabel.sizeThatFits(size).width,
             Metrics.iconToDescriptionSpacing,
         ].reduce(size.width, -)
@@ -929,7 +925,7 @@ private final class CustomContentView: UIView {
 
         // All of the icon labels should be the same size, so we only need to calculate the description width once.
         let descriptionWidthToFit = [
-            Metrics.actionIconInset,
+            Metrics.contentIconInset,
             firstIconLabel.bounds.width,
             Metrics.iconToDescriptionSpacing,
         ].reduce(bounds.width, -)
@@ -937,7 +933,7 @@ private final class CustomContentView: UIView {
 
         firstDescriptionLabel.bounds.size = firstDescriptionLabel.sizeThatFits(descriptionSizeToFit)
 
-        firstIconLabel.frame.origin = .init(x: Metrics.actionIconInset, y: firstPairYPosition)
+        firstIconLabel.frame.origin = .init(x: Metrics.contentIconInset, y: firstPairYPosition)
 
         let descriptionXPosition = firstIconLabel.frame.maxX + Metrics.iconToDescriptionSpacing
 
@@ -950,7 +946,7 @@ private final class CustomContentView: UIView {
 
             let yPosition = previousDescriptionLabel.frame.maxY + Metrics.verticalSpacing
 
-            iconLabel.frame.origin = .init(x: Metrics.actionIconInset, y: yPosition)
+            iconLabel.frame.origin = .init(x: Metrics.contentIconInset, y: yPosition)
             descriptionLabel.frame.origin = .init(x: descriptionXPosition, y: yPosition)
         }
     }
@@ -960,10 +956,11 @@ private final class CustomContentView: UIView {
     private enum Metrics {
 
         static let verticalSpacing: CGFloat = 4
-        static let actionIconInset: CGFloat = 4
+        static let contentIconInset: CGFloat = 4
         static let iconToDescriptionSpacing: CGFloat = 4
 
         static let font: UIFont = .systemFont(ofSize: 12)
+        static let boldFont: UIFont = .boldSystemFont(ofSize: 12)
 
     }
 }


### PR DESCRIPTION
Introduced in iOS 14 [Accessibility Custom Content](https://developer.apple.com/documentation/accessibility/customized_accessibility_content) allows the inclusion of arbitrary accessibility content defined using pairs of label and value. 
As a default this additional data is exposed under a "Custom Content" rotor entry, but can also be included in the element's VoiceOver utterance by setting the content's `importance` instance variable to `.high` or by adjusting verbosity in VoiceOver settings. 

This PR adds support for displaying custom content similar to how we handle custom actions.