### PR TITLE
Run carthage build with verbose flag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,4 +91,4 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v3
       - name: Build
-        run: carthage build --no-skip-current --platform iOS --use-xcframeworks
+        run: carthage build --no-skip-current --platform iOS --use-xcframeworks --verbose


### PR DESCRIPTION
Makes it _way_ easier to debug CI failures