### PR TITLE
Update ruby and bundler versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,9 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.2.2'
       - name: Bundle Install
         run: bundle install --gemfile=Example/Gemfile
       - name: Prepare Simulator Runtimes
@@ -41,6 +44,9 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.2.2'
       - name: Bundle Install
         run: bundle install --gemfile=Example/Gemfile
       - name: Select Xcode Version (12.5.1)
@@ -64,6 +70,9 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.2.2'
       - name: Bundle Install
         run: bundle install --gemfile=Example/Gemfile
       - name: Pod Install

--- a/Example/Gemfile
+++ b/Example/Gemfile
@@ -1,3 +1,6 @@
+ruby '3.2.2'
+source 'https://rubygems.org'
+
 def cocoapods_gem(name, gem_name = name.downcase, **opts)
   gem gem_name, git: "https://github.com/CocoaPods/#{name}", **opts
 end

--- a/Example/Gemfile.lock
+++ b/Example/Gemfile.lock
@@ -121,5 +121,8 @@ DEPENDENCIES
   nanaimo!
   xcodeproj!
 
+RUBY VERSION
+   ruby 3.2.2p53
+
 BUNDLED WITH
-   1.17.3
+   2.4.22


### PR DESCRIPTION
- Add the ruby version to the Gemfile so local development can match CI. 
- Update the bundler version to what is available by default in CI.
- Update CI to use the [setup-ruby](https://github.com/ruby/setup-ruby) action