### PR TITLE
Bump minimum Xcode version to 13.2.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,9 +49,6 @@ jobs:
           ruby-version: '3.2.2'
       - name: Bundle Install
         run: bundle install --gemfile=Example/Gemfile
-      - name: Select Xcode Version (12.5.1)
-        run: sudo xcode-select --switch /Applications/Xcode_12.5.1.app/Contents/Developer
-        if: matrix.platform == 'iOS_14'
       - name: Prepare Simulator Runtimes
         run: Scripts/github/prepare-simulators.sh ${{ matrix.platform }}
       - name: Pod Install
@@ -89,8 +86,8 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3
-      - name: Select Xcode Version (12.5.1)
-        run: sudo xcode-select --switch /Applications/Xcode_12.5.1.app/Contents/Developer
+      - name: Prepare Simulator Runtimes
+        run: Scripts/github/prepare-simulators.sh ${{ matrix.platform }}
       - name: Build
         run: Scripts/build.swift spm ${{ matrix.platform }}
   carthage:

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ You can also run accessibility snapshot tests from Objective-C:
 
 ## Requirements
 
-* Xcode 12.0 or later
+* Xcode 13.2.1 or later
 * iOS 13.0 or later
 
 ## Contributing

--- a/Scripts/github/prepare-simulators.sh
+++ b/Scripts/github/prepare-simulators.sh
@@ -9,6 +9,10 @@ if [[ ${PLATFORMS[*]} =~ 'iOS_16' ]]; then
 	sudo ln -s /Applications/Xcode_14.3.1.app/Contents/Developer/Platforms/iPhoneOS.platform/Library/Developer/CoreSimulator/Profiles/Runtimes/iOS.simruntime /Library/Developer/CoreSimulator/Profiles/Runtimes/iOS\ 16.4.simruntime
 fi
 
+if [[ ${PLATFORMS[*]} =~ 'iOS_14' ]]; then
+	sudo ln -s /Applications/Xcode_12.5.1.app/Contents/Developer/Platforms/iPhoneOS.platform/Library/Developer/CoreSimulator/Profiles/Runtimes/iOS.simruntime /Library/Developer/CoreSimulator/Profiles/Runtimes/iOS\ 14.5.simruntime
+fi
+
 if [[ ${PLATFORMS[*]} =~ 'iOS_13' ]]; then
 	sudo ln -s /Applications/Xcode_11.7.app/Contents/Developer/Platforms/iPhoneOS.platform/Library/Developer/CoreSimulator/Profiles/Runtimes/iOS.simruntime /Library/Developer/CoreSimulator/Profiles/Runtimes/iOS\ 13.7.simruntime
 fi


### PR DESCRIPTION
This is the highest we can bring our minimum Xcode version based on the CI virtual environments available right now.