### PR TITLE
Remove unnecessary import checks for SwiftUI

### DIFF
--- a/Example/AccessibilitySnapshot/SwiftUIView.swift
+++ b/Example/AccessibilitySnapshot/SwiftUIView.swift
@@ -14,8 +14,6 @@
 //  limitations under the License.
 //
 
-#if swift(>=5.1) && canImport(SwiftUI)
-
 import SwiftUI
 
 fileprivate struct Circle: View {
@@ -89,5 +87,3 @@ struct SwiftUIView_Previews: PreviewProvider {
             .previewLayout(.sizeThatFits)
     }
 }
-
-#endif

--- a/Example/AccessibilitySnapshot/SwiftUIViewWithScrollView.swift
+++ b/Example/AccessibilitySnapshot/SwiftUIViewWithScrollView.swift
@@ -14,8 +14,6 @@
 //  limitations under the License.
 //
 
-#if swift(>=5.1) && canImport(SwiftUI)
-
 import SwiftUI
 
 /// A SwiftUI View inside a ScrollView will produce no accessibility elements for iOS 14.0 and 14.1, for more
@@ -34,5 +32,3 @@ struct SwiftUIViewWithScrollView_Previews: PreviewProvider {
             .previewLayout(.sizeThatFits)
     }
 }
-
-#endif


### PR DESCRIPTION
Following #197 we no longer need these checks.