### PR TITLE
Add German and Russian locales to demo app

### DIFF
--- a/Example/AccessibilitySnapshot.xcodeproj/project.pbxproj
+++ b/Example/AccessibilitySnapshot.xcodeproj/project.pbxproj
@@ -89,6 +89,8 @@
 		3D13DB502221124000066519 /* SnapshotTests-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "SnapshotTests-Bridging-Header.h"; path = "Supporting Files/SnapshotTests-Bridging-Header.h"; sourceTree = "<group>"; };
 		3D13DB512221124000066519 /* ObjectiveCTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ObjectiveCTests.m; sourceTree = "<group>"; };
 		3D220A2A252AF72900359C1E /* AccessibleContainerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessibleContainerView.swift; sourceTree = "<group>"; };
+		3D2881822B6487E900F2A1EA /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/LaunchScreen.strings; sourceTree = "<group>"; };
+		3D2881832B6488B600F2A1EA /* ru */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ru; path = ru.lproj/LaunchScreen.strings; sourceTree = "<group>"; };
 		3D39BFAB223314C1009C3EF4 /* TabBarViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarViewController.swift; sourceTree = "<group>"; };
 		3D39BFAF2239BC42009C3EF4 /* ActivationPointTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivationPointTests.swift; sourceTree = "<group>"; };
 		3D39BFB12239BEA5009C3EF4 /* ActivationPointViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivationPointViewController.swift; sourceTree = "<group>"; };
@@ -448,6 +450,8 @@
 				English,
 				en,
 				Base,
+				de,
+				ru,
 			);
 			mainGroup = 607FACC71AFB9204008FA782;
 			productRefGroup = 607FACD11AFB9204008FA782 /* Products */;
@@ -680,6 +684,8 @@
 			isa = PBXVariantGroup;
 			children = (
 				607FACDF1AFB9204008FA782 /* Base */,
+				3D2881822B6487E900F2A1EA /* de */,
+				3D2881832B6488B600F2A1EA /* ru */,
 			);
 			name = LaunchScreen.xib;
 			sourceTree = "<group>";

--- a/Example/AccessibilitySnapshot.xcodeproj/xcshareddata/xcschemes/AccessibilitySnapshotDemo (de).xcscheme
+++ b/Example/AccessibilitySnapshot.xcodeproj/xcshareddata/xcschemes/AccessibilitySnapshotDemo (de).xcscheme
@@ -1,0 +1,152 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1030"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "607FACCF1AFB9204008FA782"
+               BuildableName = "AccessibilitySnapshotDemo.app"
+               BlueprintName = "AccessibilitySnapshotDemo"
+               ReferencedContainer = "container:AccessibilitySnapshot.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "607FACE41AFB9204008FA782"
+               BuildableName = "SnapshotTests.xctest"
+               BlueprintName = "SnapshotTests"
+               ReferencedContainer = "container:AccessibilitySnapshot.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "607FACCF1AFB9204008FA782"
+            BuildableName = "AccessibilitySnapshotDemo.app"
+            BlueprintName = "AccessibilitySnapshotDemo"
+            ReferencedContainer = "container:AccessibilitySnapshot.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "607FACE41AFB9204008FA782"
+               BuildableName = "SnapshotTests.xctest"
+               BlueprintName = "SnapshotTests"
+               ReferencedContainer = "container:AccessibilitySnapshot.xcodeproj">
+            </BuildableReference>
+            <SkippedTests>
+               <Test
+                  Identifier = "AccessibilityContainersTests/testDataTableWithUndefinedColumns()">
+               </Test>
+               <Test
+                  Identifier = "AccessibilityContainersTests/testDataTableWithUndefinedRowsAndColumns()">
+               </Test>
+               <Test
+                  Identifier = "AccessibilitySnapshotTests/testLargeViewInViewControllerThatRequiresTiling()">
+               </Test>
+               <Test
+                  Identifier = "AccessibilitySnapshotTests/testLargeViewThatRequiresTiling()">
+               </Test>
+               <Test
+                  Identifier = "DefaultControlsTests/testDatePicker()">
+               </Test>
+               <Test
+                  Identifier = "HitTargetTests/testPerformance()">
+               </Test>
+               <Test
+                  Identifier = "TextAccessibilityTests">
+               </Test>
+            </SkippedTests>
+         </TestableReference>
+         <TestableReference
+            skipped = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "3D881955246E03C00061DA6A"
+               BuildableName = "UnitTests.xctest"
+               BlueprintName = "UnitTests"
+               ReferencedContainer = "container:AccessibilitySnapshot.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = "de"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "607FACCF1AFB9204008FA782"
+            BuildableName = "AccessibilitySnapshotDemo.app"
+            BlueprintName = "AccessibilitySnapshotDemo"
+            ReferencedContainer = "container:AccessibilitySnapshot.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <EnvironmentVariables>
+         <EnvironmentVariable
+            key = "FB_REFERENCE_IMAGE_DIR"
+            value = "$(SOURCE_ROOT)/SnapshotTests/ReferenceImages/"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+      </EnvironmentVariables>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "607FACCF1AFB9204008FA782"
+            BuildableName = "AccessibilitySnapshotDemo.app"
+            BlueprintName = "AccessibilitySnapshotDemo"
+            ReferencedContainer = "container:AccessibilitySnapshot.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Example/AccessibilitySnapshot.xcodeproj/xcshareddata/xcschemes/AccessibilitySnapshotDemo (ru).xcscheme
+++ b/Example/AccessibilitySnapshot.xcodeproj/xcshareddata/xcschemes/AccessibilitySnapshotDemo (ru).xcscheme
@@ -1,0 +1,152 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1030"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "607FACCF1AFB9204008FA782"
+               BuildableName = "AccessibilitySnapshotDemo.app"
+               BlueprintName = "AccessibilitySnapshotDemo"
+               ReferencedContainer = "container:AccessibilitySnapshot.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "607FACE41AFB9204008FA782"
+               BuildableName = "SnapshotTests.xctest"
+               BlueprintName = "SnapshotTests"
+               ReferencedContainer = "container:AccessibilitySnapshot.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "607FACCF1AFB9204008FA782"
+            BuildableName = "AccessibilitySnapshotDemo.app"
+            BlueprintName = "AccessibilitySnapshotDemo"
+            ReferencedContainer = "container:AccessibilitySnapshot.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "607FACE41AFB9204008FA782"
+               BuildableName = "SnapshotTests.xctest"
+               BlueprintName = "SnapshotTests"
+               ReferencedContainer = "container:AccessibilitySnapshot.xcodeproj">
+            </BuildableReference>
+            <SkippedTests>
+               <Test
+                  Identifier = "AccessibilityContainersTests/testDataTableWithUndefinedColumns()">
+               </Test>
+               <Test
+                  Identifier = "AccessibilityContainersTests/testDataTableWithUndefinedRowsAndColumns()">
+               </Test>
+               <Test
+                  Identifier = "AccessibilitySnapshotTests/testLargeViewInViewControllerThatRequiresTiling()">
+               </Test>
+               <Test
+                  Identifier = "AccessibilitySnapshotTests/testLargeViewThatRequiresTiling()">
+               </Test>
+               <Test
+                  Identifier = "DefaultControlsTests/testDatePicker()">
+               </Test>
+               <Test
+                  Identifier = "HitTargetTests/testPerformance()">
+               </Test>
+               <Test
+                  Identifier = "TextAccessibilityTests">
+               </Test>
+            </SkippedTests>
+         </TestableReference>
+         <TestableReference
+            skipped = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "3D881955246E03C00061DA6A"
+               BuildableName = "UnitTests.xctest"
+               BlueprintName = "UnitTests"
+               ReferencedContainer = "container:AccessibilitySnapshot.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = "ru"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "607FACCF1AFB9204008FA782"
+            BuildableName = "AccessibilitySnapshotDemo.app"
+            BlueprintName = "AccessibilitySnapshotDemo"
+            ReferencedContainer = "container:AccessibilitySnapshot.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <EnvironmentVariables>
+         <EnvironmentVariable
+            key = "FB_REFERENCE_IMAGE_DIR"
+            value = "$(SOURCE_ROOT)/SnapshotTests/ReferenceImages/"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+      </EnvironmentVariables>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "607FACCF1AFB9204008FA782"
+            BuildableName = "AccessibilitySnapshotDemo.app"
+            BlueprintName = "AccessibilitySnapshotDemo"
+            ReferencedContainer = "container:AccessibilitySnapshot.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Example/AccessibilitySnapshot/de.lproj/LaunchScreen.strings
+++ b/Example/AccessibilitySnapshot/de.lproj/LaunchScreen.strings
@@ -1,0 +1,6 @@
+
+/* Class = "UILabel"; text = "  Copyright (c) 2015 CocoaPods. All rights reserved."; ObjectID = "8ie-xW-0ye"; */
+"8ie-xW-0ye.text" = "  Copyright (c) 2015 CocoaPods. All rights reserved.";
+
+/* Class = "UILabel"; text = "AccessibilitySnapshot"; ObjectID = "kId-c2-rCX"; */
+"kId-c2-rCX.text" = "AccessibilitySnapshot";

--- a/Example/AccessibilitySnapshot/ru.lproj/LaunchScreen.strings
+++ b/Example/AccessibilitySnapshot/ru.lproj/LaunchScreen.strings
@@ -1,0 +1,6 @@
+
+/* Class = "UILabel"; text = "  Copyright (c) 2015 CocoaPods. All rights reserved."; ObjectID = "8ie-xW-0ye"; */
+"8ie-xW-0ye.text" = "  Copyright (c) 2015 CocoaPods. All rights reserved.";
+
+/* Class = "UILabel"; text = "AccessibilitySnapshot"; ObjectID = "kId-c2-rCX"; */
+"kId-c2-rCX.text" = "AccessibilitySnapshot";


### PR DESCRIPTION
Listing these as supported locales and adding the associated schemes makes it easier to run the demo app to get the translated strings from VoiceOver.