### PR TITLE
Bump Version to 0.7.0

### DIFF
--- a/AccessibilitySnapshot.podspec
+++ b/AccessibilitySnapshot.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'AccessibilitySnapshot'
-  s.version          = '0.6.0'
+  s.version          = '0.7.0'
   s.summary          = 'Easy regression testing for iOS accessibility'
 
   s.homepage         = 'https://github.com/CashApp/AccessibilitySnapshot'

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,9 +1,9 @@
 PODS:
-  - AccessibilitySnapshot/Core (0.6.0)
-  - AccessibilitySnapshot/iOSSnapshotTestCase (0.6.0):
+  - AccessibilitySnapshot/Core (0.7.0)
+  - AccessibilitySnapshot/iOSSnapshotTestCase (0.7.0):
     - AccessibilitySnapshot/Core
     - iOSSnapshotTestCase (~> 8.0)
-  - AccessibilitySnapshot/SnapshotTesting (0.6.0):
+  - AccessibilitySnapshot/SnapshotTesting (0.7.0):
     - AccessibilitySnapshot/Core
     - SnapshotTesting (~> 1.0)
   - iOSSnapshotTestCase (8.0.0):
@@ -32,7 +32,7 @@ EXTERNAL SOURCES:
     :path: "../AccessibilitySnapshot.podspec"
 
 SPEC CHECKSUMS:
-  AccessibilitySnapshot: 19f165d0397a18f7dd8dbc5f3396e5670c75a1a4
+  AccessibilitySnapshot: a29652b9054223b6c2a19ef1c83631e2a62ecbf9
   iOSSnapshotTestCase: a670511f9ee3829c2b9c23e6e68f315fd7b6790f
   Paralayout: 844978af530a061a31d849c7b554510190b9cddf
   SnapshotTesting: 8caa6661fea7c8019d5b46de77c16bab99c36c5c


### PR DESCRIPTION
It appears that we haven't published a pod  since January 2023.

**Full Changelog**: https://github.com/cashapp/AccessibilitySnapshot/compare/0.6.0...alex/v0.7.0