### PR TITLE
Sketch of VoiceOver SwiftUI previews

### DIFF
--- a/AccessibilitySnapshot.podspec
+++ b/AccessibilitySnapshot.podspec
@@ -12,16 +12,7 @@ Pod::Spec.new do |s|
 
   s.ios.deployment_target = '13.0'
 
-  s.default_subspecs = 'Core', 'SnapshotTesting'
-
-  s.subspec 'Core' do |ss|
-    ss.source_files = 'Sources/AccessibilitySnapshot/Core/Swift/Classes/**/*.swift', 'Sources/AccessibilitySnapshot/Core/ObjC/**/*.{h,m}'
-    ss.public_header_files = 'Sources/AccessibilitySnapshot/Core/ObjC/include/*.h'
-    ss.resources = 'Sources/AccessibilitySnapshot/Core/Swift/Assets/**/*.{strings,xcassets}'
-    ss.resource_bundles = {
-     'AccessibilitySnapshot' => ['Sources/AccessibilitySnapshot/Core/Swift/Assets/**/*.{strings,xcassets}']
-    }
-  end
+  s.default_subspecs = 'SnapshotTesting'
 
   s.subspec 'iOSSnapshotTestCase' do |ss|
     ss.source_files = 'Sources/AccessibilitySnapshot/iOSSnapshotTestCase/**/*.{swift,h,m}'
@@ -29,7 +20,7 @@ Pod::Spec.new do |s|
       'Sources/AccessibilitySnapshot/iOSSnapshotTestCase/ObjC/include/*.h',
     ]
 
-    ss.dependency 'AccessibilitySnapshot/Core'
+    ss.dependency 'AccessibilitySnapshotCore'
     ss.dependency 'iOSSnapshotTestCase', '~> 8.0'
     ss.frameworks = 'XCTest'
     ss.weak_frameworks = 'XCTest'
@@ -38,7 +29,7 @@ Pod::Spec.new do |s|
   s.subspec 'SnapshotTesting' do |ss|
     ss.source_files = 'Sources/AccessibilitySnapshot/SnapshotTesting/**/*.{swift,h,m}'
 
-    ss.dependency 'AccessibilitySnapshot/Core'
+    ss.dependency 'AccessibilitySnapshotCore'
     ss.dependency 'SnapshotTesting', '~> 1.0'
     ss.frameworks = 'XCTest'
     ss.weak_frameworks = 'XCTest'

--- a/AccessibilitySnapshotCore.podspec
+++ b/AccessibilitySnapshotCore.podspec
@@ -1,0 +1,21 @@
+Pod::Spec.new do |s|
+  s.name             = 'AccessibilitySnapshotCore'
+  s.version          = '0.6.0'
+  s.summary          = 'Easy regression testing for iOS accessibility'
+
+  s.homepage         = 'https://github.com/CashApp/AccessibilitySnapshot'
+  s.license          = { :type => 'Apache License, Version 2.0', :file => 'LICENSE' }
+  s.authors          = 'Square'
+  s.source           = { :git => 'https://github.com/CashApp/AccessibilitySnapshot.git', :tag => s.version.to_s }
+
+  s.swift_version = '5.0.1'
+
+  s.ios.deployment_target = '13.0'
+
+  s.source_files = 'Sources/AccessibilitySnapshot/Core/Swift/Classes/**/*.swift', 'Sources/AccessibilitySnapshot/Core/ObjC/**/*.{h,m}','Sources/AccessibilitySnapshot/Core/Swift/AccessibilityPreview/**/*.swift'
+  s.public_header_files = 'Sources/AccessibilitySnapshot/Core/ObjC/include/*.h'
+  s.resources = 'Sources/AccessibilitySnapshot/Core/Swift/Assets/**/*.{strings,xcassets}'
+  s.resource_bundles = {
+   'AccessibilitySnapshot' => ['Sources/AccessibilitySnapshot/Core/Swift/Assets/**/*.{strings,xcassets}']
+  }
+end

--- a/Example/AccessibilitySnapshot.xcodeproj/project.pbxproj
+++ b/Example/AccessibilitySnapshot.xcodeproj/project.pbxproj
@@ -84,6 +84,8 @@
 		1104A8CE2B580AC500B6715F /* SwiftUITextEntry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftUITextEntry.swift; sourceTree = "<group>"; };
 		1104A8D02B595FF600B6715F /* TextFieldViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextFieldViewController.swift; sourceTree = "<group>"; };
 		112909BB2B63E57B00B4EBEB /* TextViewViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextViewViewController.swift; sourceTree = "<group>"; };
+		11D41CA12B989D7C005FD932 /* AccessibilitySnapshot.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = AccessibilitySnapshot.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		11D41CA32B989DEF005FD932 /* AccessibilitySnapshot.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = AccessibilitySnapshot.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		1635CE4D251EAC6700907101 /* SnapshotTestingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnapshotTestingTests.swift; sourceTree = "<group>"; };
 		358D84DCD315110A89BD052E /* Pods-UnitTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-UnitTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-UnitTests/Pods-UnitTests.debug.xcconfig"; sourceTree = "<group>"; };
 		3A3192D7B9B16BD10FB517A2 /* Pods_SnapshotTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_SnapshotTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -355,6 +357,8 @@
 		63E74EA01571917A22FCFF95 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				11D41CA32B989DEF005FD932 /* AccessibilitySnapshot.framework */,
+				11D41CA12B989D7C005FD932 /* AccessibilitySnapshot.framework */,
 				6A886964D2E787399E137105 /* Pods_AccessibilitySnapshotDemo.framework */,
 				3A3192D7B9B16BD10FB517A2 /* Pods_SnapshotTests.framework */,
 				0BFCB4FD6BC17AB232B26E72 /* Pods_UnitTests.framework */,

--- a/Example/AccessibilitySnapshot/SwiftUITextEntry.swift
+++ b/Example/AccessibilitySnapshot/SwiftUITextEntry.swift
@@ -14,23 +14,49 @@
 //  limitations under the License.
 //
 
+import AccessibilitySnapshotCore
 import SwiftUI
 
 struct SwiftUITextEntry: View {
+    @State private var textField1 = ""
+    @State private var textField2 = "Value in Text Field"
+    @State private var textEditor1 = ""
+
     var body: some View {
         VStack {
-            TextField("SwiftUI Text Field", text: .constant(""))
-            TextField("SwiftUI Text Field", text: .constant("Value in Text Field"))
+            TextField("SwiftUI Text Field", text: $textField1)
+            TextField("SwiftUI Text Field", text: $textField2)
             if #available(iOS 14.0, *) {
-                TextEditor(text: .constant(""))
+                TextEditor(text: $textEditor1)
+                    .frame(height: 300)
             }
+        }
+    }
+}
+
+struct Preview: View {
+    @State private var isPresented = true
+
+    var body: some View {
+        if #available(iOS 15.0, *) {
+            SwiftUITextEntry()
+                .accessibilityPreview(isPresented: $isPresented)
+        } else {
+            SwiftUITextEntry()
         }
     }
 }
 
 struct SwiftUITextEntry_Previews: PreviewProvider {
     static var previews: some View {
-        SwiftUITextEntry()
-            .previewLayout(.sizeThatFits)
+        if #available(iOS 15.0, *) {
+            SwiftUITextEntry()
+                .accessibilityPreview()
+//                    Preview()
+                .previewLayout(.sizeThatFits)
+        } else {
+            SwiftUITextEntry()
+                .previewLayout(.sizeThatFits)
+        }
     }
 }

--- a/Example/Podfile
+++ b/Example/Podfile
@@ -3,11 +3,13 @@ use_modular_headers!
 platform :ios, '13.0'
 
 target 'AccessibilitySnapshotDemo' do
+	pod 'AccessibilitySnapshotCore', :path => '../AccessibilitySnapshotCore.podspec'
 	pod 'Paralayout', '= 1.0.0-rc.5'
 
 	target 'SnapshotTests' do
 		inherit! :search_paths
 
+		pod 'AccessibilitySnapshotCore', :path => '../AccessibilitySnapshotCore.podspec'
 		pod 'AccessibilitySnapshot/iOSSnapshotTestCase', :path => '../AccessibilitySnapshot.podspec'
 		pod 'AccessibilitySnapshot/SnapshotTesting', :path => '../AccessibilitySnapshot.podspec'
 
@@ -19,7 +21,7 @@ target 'AccessibilitySnapshotDemo' do
 	target 'UnitTests' do
 		inherit! :search_paths
 
-		pod 'AccessibilitySnapshot/Core', :path => '../AccessibilitySnapshot.podspec'
+		pod 'AccessibilitySnapshotCore', :path => '../AccessibilitySnapshotCore.podspec'
 	end
 end
 

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,11 +1,11 @@
 PODS:
-  - AccessibilitySnapshot/Core (0.6.0)
   - AccessibilitySnapshot/iOSSnapshotTestCase (0.6.0):
-    - AccessibilitySnapshot/Core
+    - AccessibilitySnapshotCore
     - iOSSnapshotTestCase (~> 8.0)
   - AccessibilitySnapshot/SnapshotTesting (0.6.0):
-    - AccessibilitySnapshot/Core
+    - AccessibilitySnapshotCore
     - SnapshotTesting (~> 1.0)
+  - AccessibilitySnapshotCore (0.6.0)
   - iOSSnapshotTestCase (8.0.0):
     - iOSSnapshotTestCase/SwiftSupport (= 8.0.0)
   - iOSSnapshotTestCase/Core (8.0.0)
@@ -15,9 +15,9 @@ PODS:
   - SnapshotTesting (1.7.2)
 
 DEPENDENCIES:
-  - AccessibilitySnapshot/Core (from `../AccessibilitySnapshot.podspec`)
   - AccessibilitySnapshot/iOSSnapshotTestCase (from `../AccessibilitySnapshot.podspec`)
   - AccessibilitySnapshot/SnapshotTesting (from `../AccessibilitySnapshot.podspec`)
+  - AccessibilitySnapshotCore (from `../AccessibilitySnapshotCore.podspec`)
   - Paralayout (= 1.0.0-rc.5)
   - SnapshotTesting (= 1.7.2)
 
@@ -30,13 +30,16 @@ SPEC REPOS:
 EXTERNAL SOURCES:
   AccessibilitySnapshot:
     :path: "../AccessibilitySnapshot.podspec"
+  AccessibilitySnapshotCore:
+    :path: "../AccessibilitySnapshotCore.podspec"
 
 SPEC CHECKSUMS:
-  AccessibilitySnapshot: 19f165d0397a18f7dd8dbc5f3396e5670c75a1a4
+  AccessibilitySnapshot: 0b9fcf5147cd7330c8752adbe499bef466b5110a
+  AccessibilitySnapshotCore: 6f7fd2b00641c6670c267d830559412d9dd98cd5
   iOSSnapshotTestCase: a670511f9ee3829c2b9c23e6e68f315fd7b6790f
   Paralayout: 844978af530a061a31d849c7b554510190b9cddf
   SnapshotTesting: 8caa6661fea7c8019d5b46de77c16bab99c36c5c
 
-PODFILE CHECKSUM: de5390900844b21156469b30e094a6bba820f0df
+PODFILE CHECKSUM: e150693187722707ffed788dd0840565ad4803df
 
 COCOAPODS: 1.11.3

--- a/Example/SnapshotTests/HitTargetTests.swift
+++ b/Example/SnapshotTests/HitTargetTests.swift
@@ -15,6 +15,7 @@
 //
 
 import AccessibilitySnapshot
+import AccessibilitySnapshotCore
 import FBSnapshotTestCase
 import Paralayout
 

--- a/Example/UnitTests/AccessibilityHierarchyParserTests.swift
+++ b/Example/UnitTests/AccessibilityHierarchyParserTests.swift
@@ -14,7 +14,7 @@
 //  limitations under the License.
 //
 
-import AccessibilitySnapshot
+import AccessibilitySnapshotCore
 import UIKit
 import XCTest
 

--- a/Example/UnitTests/UIAccessibilityStatusUtilityObjCTests.m
+++ b/Example/UnitTests/UIAccessibilityStatusUtilityObjCTests.m
@@ -14,7 +14,7 @@
 //  limitations under the License.
 //
 
-@import AccessibilitySnapshot;
+@import AccessibilitySnapshotCore;
 @import XCTest;
 
 

--- a/Example/UnitTests/UIAccessibilityStatusUtilityTests.swift
+++ b/Example/UnitTests/UIAccessibilityStatusUtilityTests.swift
@@ -16,7 +16,7 @@
 
 import XCTest
 
-@testable import AccessibilitySnapshot
+@testable import AccessibilitySnapshotCore
 
 final class UIAccessibilityStatusUtilityTests: XCTestCase {
 

--- a/Sources/AccessibilitySnapshot/Core/Swift/AccessibilityPreview/AccessibilityPreview.swift
+++ b/Sources/AccessibilitySnapshot/Core/Swift/AccessibilityPreview/AccessibilityPreview.swift
@@ -1,0 +1,180 @@
+//
+//  Copyright 2024 ___ORGANIZATIONNAME___
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import SwiftUI
+
+extension View {
+  /// Adds a button to a view that will show a sheet with the accessibility snapshot for the view.
+  @available(iOS 15.0, *)
+  @ViewBuilder
+  public func accessibilityPreview() -> some View {
+    AccessibilityPreview {
+      self
+    }
+  }
+
+  /// Adds a button to a view that will show a sheet with the accessibility snapshot for the view.
+  ///
+  /// This modifier allows the client to determine when the accessibility snapshot sheet will be shown. One use case for this is when you want the accessibility snapshot shown on every code change. In that case you could pass in a `.constant(true)` binding, like so:
+  /// ```swift
+  /// ...
+  ///     MyView()
+  ///       .accessibilityPreview(isPresented: .constant(true))
+  /// ...
+  /// ```
+  /// - Parameter isPresented: A binding to a bool that controls the presentation of the accessibility snapshot.
+  @available(iOS 15.0, *)
+  @ViewBuilder
+  public func accessibilityPreview(isPresented: Binding<Bool>) -> some View {
+    AccessibilityPreview(isPresented: isPresented) {
+      self
+    }
+  }
+}
+
+@available(iOS 15.0, *)
+struct AccessibilityPreview<Content: View>: View {
+  private class ViewModel: ObservableObject {
+    @Published var height = 0.0
+    @Published var isPresented = false
+    @Binding private var boundIsPresented: Bool
+
+    init(isPresented: Binding<Bool>) {
+      self.isPresented = isPresented.wrappedValue
+      self._boundIsPresented = isPresented
+    }
+
+    func setHeight(_ height: CGFloat) {
+      self.height = height
+    }
+
+    func setIsPresented(_ isPresented: Bool) {
+      self.isPresented = isPresented
+      self._boundIsPresented.wrappedValue = isPresented
+    }
+  }
+
+  @ViewBuilder let content: () -> Content
+  @StateObject private var viewModel: ViewModel
+
+  init(
+    isPresented: Binding<Bool>? = nil,
+    @ViewBuilder content: @escaping () -> Content
+  ) {
+    self.content = content
+
+    self._viewModel = StateObject(
+      wrappedValue: ViewModel(
+        isPresented: isPresented ?? .constant(false)
+      )
+    )
+  }
+
+  var body: some View {
+    content().sheet(isPresented: $viewModel.isPresented) {
+      NavigationView {
+        AccessibilityPreviewViewRepresentable(height: viewModel.height) {
+          content()
+        }
+        .toolbar {
+          ToolbarItem(placement: .topBarTrailing) {
+            Button {
+              viewModel.setIsPresented(false)
+            } label: {
+              Text("Close")
+            }
+          }
+        }
+        .navigationTitle("VoiceOver Accessibility")
+        .navigationBarTitleDisplayMode(.inline)
+        .navigationViewStyle(.stack)
+      }
+    }
+    .background {
+      GeometryReader { proxy in
+        Color.clear
+          .onAppear {
+            viewModel.setHeight(proxy.size.height)
+          }
+      }
+    }
+    .overlay(alignment: .bottomTrailing) {
+      Button {
+        viewModel.setIsPresented(true)
+      } label: {
+        Text("Show VoiceOver accessibility")
+      }
+      .padding()
+    }
+  }
+}
+
+struct AccessibilityPreviewViewRepresentable<V: View>: UIViewRepresentable {
+  var height: CGFloat
+  @ViewBuilder var content: V
+
+  func makeUIView(context: Context) -> UIView {
+    let hostingController = UIHostingController(
+      rootView: content
+    )
+
+    // TODO: Get a more reliable status bar height
+    hostingController.view.frame = CGRect(
+      x: 0,
+      y: 30, // status bar height due to modal
+      width: UIScreen.main.bounds.width,
+      height: height
+    )
+
+    let accessibilitySnapshotView = AccessibilitySnapshotView(
+      containedView: hostingController.view,
+      viewRenderingMode: .drawHierarchyInRect,
+      activationPointDisplayMode: .always,
+      showUserInputLabels: false
+    )
+
+    // TODO: Should `isPreview` work differently at larger viewport widths?
+    accessibilitySnapshotView.isPreview = true
+
+    // TODO: Is `UIScreen.main.bounds` a safe assumption for previews?
+    let scrollView = UIScrollView(
+      frame: .init(
+        x: 0,
+        y: 0,
+        width: UIScreen.main.bounds.width,
+        height: UIScreen.main.bounds.height
+      )
+    )
+    scrollView.addSubview(accessibilitySnapshotView)
+    scrollView.alwaysBounceVertical = true
+
+    // Wait a fraction of a second to ensure the view is in the view hierarchy.
+    DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(100)) {
+      try? accessibilitySnapshotView.parseAccessibility(useMonochromeSnapshot: true)
+      let size = accessibilitySnapshotView.sizeThatFits(UIScreen.main.bounds.size)
+
+      scrollView.contentSize = size
+    }
+
+    return scrollView
+  }
+
+  func updateUIView(_ uiView: UIView, context: Context) {
+    // no-op
+  }
+
+  typealias UIViewType = UIView
+}

--- a/Sources/AccessibilitySnapshot/Core/Swift/Classes/SnapshotAndLegendView.swift
+++ b/Sources/AccessibilitySnapshot/Core/Swift/Classes/SnapshotAndLegendView.swift
@@ -36,6 +36,8 @@ public class SnapshotAndLegendView: UIView {
 
     internal let snapshotView: UIImageView = .init()
 
+    internal var isPreview: Bool = false
+
     internal var legendViews: [UIView] {
         // This is intended to be overridden and implemented by subclasses.
         return []
@@ -186,7 +188,9 @@ public class SnapshotAndLegendView: UIView {
     private func legendLocation(viewSize: CGSize) -> LegendLocation {
         let aspectRatio = viewSize.width / viewSize.height
 
-        if aspectRatio > 1 || viewSize.width < minimumWidth {
+        if aspectRatio > 1 ||
+            viewSize.width < minimumWidth ||
+            isPreview {
             // Wide views should display the legend underneath the snapshotted view. Small views are an exception, as
             // all views smaller than the minimum width should display the legend underneath.
             let contentWidth = max(viewSize.width, minimumWidth)

--- a/Sources/AccessibilitySnapshot/SnapshotTesting/SnapshotTesting+Accessibility.swift
+++ b/Sources/AccessibilitySnapshot/SnapshotTesting/SnapshotTesting+Accessibility.swift
@@ -20,6 +20,8 @@ import UIKit
 #if SWIFT_PACKAGE || BAZEL_PACKAGE
 import AccessibilitySnapshotCore
 import AccessibilitySnapshotCore_ObjC
+#else
+import AccessibilitySnapshotCore
 #endif
 
 extension Snapshotting where Value == UIView, Format == UIImage {

--- a/Sources/AccessibilitySnapshot/SnapshotTesting/SnapshotTesting+SwiftUI.swift
+++ b/Sources/AccessibilitySnapshot/SnapshotTesting/SnapshotTesting+SwiftUI.swift
@@ -21,6 +21,8 @@ import UIKit
 #if SWIFT_PACKAGE || BAZEL_PACKAGE
 import AccessibilitySnapshotCore
 import AccessibilitySnapshotCore_ObjC
+#else
+import AccessibilitySnapshotCore
 #endif
 
 extension Snapshotting where Value: SwiftUI.View, Format == UIImage {

--- a/Sources/AccessibilitySnapshot/iOSSnapshotTestCase/Swift/ErrorMessageFactory.swift
+++ b/Sources/AccessibilitySnapshot/iOSSnapshotTestCase/Swift/ErrorMessageFactory.swift
@@ -16,9 +16,7 @@
 
 import Foundation
 
-#if SWIFT_PACKAGE || BAZEL_PACKAGE
 import AccessibilitySnapshotCore
-#endif
 
 internal enum ErrorMessageFactory {
 

--- a/Sources/AccessibilitySnapshot/iOSSnapshotTestCase/Swift/FBSnapshotTestCase+Accessibility.swift
+++ b/Sources/AccessibilitySnapshot/iOSSnapshotTestCase/Swift/FBSnapshotTestCase+Accessibility.swift
@@ -21,6 +21,7 @@ import AccessibilitySnapshotCore
 import AccessibilitySnapshotCore_ObjC
 import iOSSnapshotTestCase
 #else
+import AccessibilitySnapshotCore
 import FBSnapshotTestCase
 #endif
 

--- a/Sources/AccessibilitySnapshot/iOSSnapshotTestCase/Swift/FBSnapshotTestCase+ImpreciseAccessibility.swift
+++ b/Sources/AccessibilitySnapshot/iOSSnapshotTestCase/Swift/FBSnapshotTestCase+ImpreciseAccessibility.swift
@@ -21,6 +21,7 @@ import AccessibilitySnapshotCore
 import AccessibilitySnapshotCore_ObjC
 import iOSSnapshotTestCase
 #else
+import AccessibilitySnapshotCore
 import FBSnapshotTestCase
 #endif
 

--- a/Sources/AccessibilitySnapshot/iOSSnapshotTestCase/Swift/FBSnapshotTestCase+ObjCSupport.swift
+++ b/Sources/AccessibilitySnapshot/iOSSnapshotTestCase/Swift/FBSnapshotTestCase+ObjCSupport.swift
@@ -19,6 +19,7 @@ import AccessibilitySnapshotCore
 import AccessibilitySnapshotCore_ObjC
 import iOSSnapshotTestCase
 #else
+import AccessibilitySnapshotCore
 import FBSnapshotTestCase
 #endif
 

--- a/Sources/AccessibilitySnapshot/iOSSnapshotTestCase/Swift/FBSnapshotTestCase+SwiftUI.swift
+++ b/Sources/AccessibilitySnapshot/iOSSnapshotTestCase/Swift/FBSnapshotTestCase+SwiftUI.swift
@@ -20,6 +20,7 @@ import SwiftUI
 import AccessibilitySnapshotCore
 import iOSSnapshotTestCase
 #else
+import AccessibilitySnapshotCore
 import FBSnapshotTestCase
 #endif
 


### PR DESCRIPTION
This pull request is a sketch of what VoiceOver SwiftUI previews could look like.

Here are some decisions I made in this implementation:

* Created a modifier that could be added on top of an existing preview so multiple previews were not needed. This means that a button must be pressed, or a binding must be set to true, to see the VoiceOver preview
* Used the existing `AccessibilitySnapshotView`, including the snapshot of the content, rather than rendering the bounding boxes on top of the existing view
* Placed the legend below the view that has been snapshotted 

Here is a screen recording of the preview in action:

https://github.com/cashapp/AccessibilitySnapshot/assets/1452879/67ecc3f9-8264-41f5-8bbc-bf6e0b450ed6