### PR TITLE
Add a minimum macOS version that matches the SnapshotTesting dependency

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -8,6 +8,7 @@ let package = Package(
     defaultLocalization: "en",
     platforms: [
         .iOS(.v13),
+        .macOS(.v10_15),
     ],
     products: [
         // Core + SnapshotTesting for image comparison


### PR DESCRIPTION
The SnapshotTesting dependency specifies 10.15 as the minimum version. Even though _this_ library doesn't support macOS, it's helpful to specify one that's compatible with its dependencies so it can be consumed in mixed-platform packages. Today, if a mixed iOS/macOS package depends on AccessibilitySnapshot, SPM emits an error:

```
error: the library 'AccessibilitySnapshot' requires macos 10.13, but depends on the product 'SnapshotTesting' which requires macos 10.15;
consider changing the library 'AccessibilitySnapshot' to require macos 10.15 or later, or the product 'SnapshotTesting' to require macos 10.13 or earlier.
```