### PR TITLE
Add support for keyboard key accessibility trait

### DIFF
--- a/Sources/AccessibilitySnapshot/Core/Swift/Assets/de.lproj/Localizable.strings
+++ b/Sources/AccessibilitySnapshot/Core/Swift/Assets/de.lproj/Localizable.strings
@@ -13,6 +13,9 @@
 /* Description for the 'back button' accessibility trait */
 "trait.backbutton.description" = "Zurück Taste.";
 
+/* Description for the 'keyboard key' accessibility trait */
+"trait.keyboard_key.description" = "Tastaturtaste.";
+
 /* Description for the 'tab' accessibility trait */
 "trait.tab.description" = "Tabulator.";
 

--- a/Sources/AccessibilitySnapshot/Core/Swift/Assets/en.lproj/Localizable.strings
+++ b/Sources/AccessibilitySnapshot/Core/Swift/Assets/en.lproj/Localizable.strings
@@ -13,6 +13,9 @@
 /* Description for the 'back button' accessibility trait */
 "trait.backbutton.description" = "Back Button.";
 
+/* Description for the 'keyboard key' accessibility trait */
+"trait.keyboard_key.description" = "Keyboard Key.";
+
 /* Description for the 'tab' accessibility trait */
 "trait.tab.description" = "Tab.";
 

--- a/Sources/AccessibilitySnapshot/Core/Swift/Assets/ru.lproj/Localizable.strings
+++ b/Sources/AccessibilitySnapshot/Core/Swift/Assets/ru.lproj/Localizable.strings
@@ -13,6 +13,9 @@
 /* Description for the 'back button' accessibility trait */
 "trait.backbutton.description" = "Кнопка назад.";
 
+/* Description for the 'keyboard key' accessibility trait */
+"trait.keyboard_key.description" = "Клавиша клавиатуры.";
+
 /* Description for the 'tab' accessibility trait */
 "trait.tab.description" = "Вкладка.";
 

--- a/Sources/AccessibilitySnapshot/Core/Swift/Classes/UIAccessibility+SnapshotAdditions.swift
+++ b/Sources/AccessibilitySnapshot/Core/Swift/Classes/UIAccessibility+SnapshotAdditions.swift
@@ -110,6 +110,10 @@ extension NSObject {
             traitSpecifiers.append(strings.backButtonTraitName)
         }
 
+        if accessibilityTraits.contains(.keyboardKey) {
+            traitSpecifiers.append(strings.keyboardKeyTraitName)
+        }
+
         if accessibilityTraits.contains(.switchButton) {
             if accessibilityTraits.contains(.button) {
                 // An element can have the private switch button trait without being a UISwitch (for example, by passing
@@ -326,6 +330,8 @@ extension NSObject {
         
         let backButtonTraitName: String
 
+        let keyboardKeyTraitName: String
+
         let tabTraitName: String
 
         let headerTraitName: String
@@ -408,6 +414,11 @@ extension NSObject {
             self.backButtonTraitName = "Back Button.".localized(
                 key: "trait.backbutton.description",
                 comment: "Description for the 'back button' accessibility trait",
+                locale: locale
+            )
+            self.keyboardKeyTraitName = "Keyboard Key.".localized(
+                key: "trait.keyboard_key.description",
+                comment: "Description for the 'keyboard key' accessibility trait",
                 locale: locale
             )
             self.tabTraitName = "Tab.".localized(


### PR DESCRIPTION
The `.keyboardKey` trait was previously not surfaced in the snapshot annotations. It is a crucial trait to provide to buttons that behave like keyboard keys so that a user may use touch typing or direct touch typing depending on their VoiceOver configuration.

[Reference](https://mobilea11y.com/blog/traits/#:~:text=activating%20a%20button.-,Keyboard%20Key,-Use%20this%20trait)