### PR TITLE
Update CI for macos 12 deprecation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,33 +34,6 @@ jobs:
         with:
           name: Test Results (${{ matrix.platform }})
           path: .build/derivedData/**/Logs/Test/*.xcresult
-  xcode-build-legacy:
-    name: Xcode Build
-    runs-on: macOS-12
-    strategy:
-      matrix:
-        platform: ['iOS_15']
-      fail-fast: false
-    steps:
-      - name: Checkout Repo
-        uses: actions/checkout@v4
-      - uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: '3.2.2'
-      - name: Bundle Install
-        run: bundle install --gemfile=Example/Gemfile
-      - name: Prepare Simulator Runtimes
-        run: Scripts/github/prepare-simulators.sh ${{ matrix.platform }}
-      - name: Pod Install
-        run: bundle exec --gemfile=Example/Gemfile pod install --project-directory=Example
-      - name: Build and Test
-        run: Scripts/build.swift xcode ${{ matrix.platform }} `which xcpretty`
-      - name: Upload Results
-        uses: actions/upload-artifact@v4
-        if: failure()
-        with:
-          name: Test Results (${{ matrix.platform }})
-          path: .build/derivedData/**/Logs/Test/*.xcresult
   pod-lint:
     name: Pod Lint
     runs-on: macOS-13

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
           path: .build/derivedData/**/Logs/Test/*.xcresult
   pod-lint:
     name: Pod Lint
-    runs-on: macOS-12
+    runs-on: macOS-13
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
@@ -78,10 +78,10 @@ jobs:
         run: bundle exec --gemfile=Example/Gemfile pod lib lint --verbose --fail-fast
   spm:
     name: SPM Build
-    runs-on: macOS-12
+    runs-on: macOS-13
     strategy:
       matrix:
-        platform: ['iOS_15']
+        platform: ['iOS_16']
       fail-fast: false
     steps:
       - name: Checkout Repo


### PR DESCRIPTION
GitHub's macos 12 runner has been deprecated and is no longer available.
this PR updates jobs to use 13 where possible while removing the legacy test run as ios 15 is no longer available. 


https://github.com/actions/runner-images/issues/10721