### PR TITLE
fix: casting each element individually to avoid side effects.

### DIFF
--- a/Sources/AccessibilitySnapshot/Core/Swift/Classes/AccessibilityHierarchyParser.swift
+++ b/Sources/AccessibilitySnapshot/Core/Swift/Classes/AccessibilityHierarchyParser.swift
@@ -609,7 +609,7 @@ private extension NSObject {
         if isAccessibilityElement {
             recursiveAccessibilityHierarchy.append(.element(self, contextProvider: contextProvider))
 
-        } else if let accessibilityElements = accessibilityElements as? [NSObject] {
+        } else if let accessibilityElements = accessibilityElements?.compactMap({ $0 as? NSObject}) {
             var accessibilityHierarchyOfElements: [AccessibilityNode] = []
             for element in accessibilityElements {
                 accessibilityHierarchyOfElements.append(


### PR DESCRIPTION
Replaces a bulk cast of `accessibilityElements as? [NSObject]` with `accessibilityElements.compactMap { $0 as? NSObject }`.

This avoids unintended setter invocations observed during snapshot tests when SwiftUI.AccessibilityNode instances are present in the hierarchy. The original cast causes Swift to evaluate conformance across the full array, which triggers SwiftUI to resolve these nodes — potentially re-entering the view graph and mutating state.

This was first observed when snapshotting a SwiftUI View that wraps a UIKit subclass, In this case a UITextField, caused an overridden `accessibilityCustomRotors` setter to be called with a nil value. 

The change is behaviorally neutral but eliminates a source of hidden side effects during accessibility introspection.