### PR TITLE
allowing dismissing of view controllers in the example app

### DIFF
--- a/Example/AccessibilitySnapshot/RootViewController.swift
+++ b/Example/AccessibilitySnapshot/RootViewController.swift
@@ -105,8 +105,14 @@ final class RootViewController: UITableViewController {
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         let viewController = accessibilityScreens[indexPath.row].1(self)
         viewController.modalPresentationStyle = .fullScreen
-        present(viewController, animated: true, completion: nil)
+        let navigationController = UINavigationController(rootViewController: viewController)
+        viewController.navigationItem.leftBarButtonItem = UIBarButtonItem(image: .init(systemName: "xmark"), style: .plain, target: self, action: #selector(dismiss(_:)))
+        present(navigationController, animated: true, completion: nil)
         tableView.deselectRow(at: indexPath, animated: true)
     }
 
+    @objc
+    func dismiss(_ sender: UIViewController) {
+        self.dismiss(animated: true, completion: nil)
+    }
 }


### PR DESCRIPTION
Something small that came up on a call with me and @RoyalPineapple today, you can't dismiss view controllers after they've been presented, you have to kill the app. This fixes that.