### PR TITLE
Don't crash the host process when the parser hits an unexpected hierarchy

### DIFF
--- a/Example/UnitTests/AccessibilityHierarchyParserTests.swift
+++ b/Example/UnitTests/AccessibilityHierarchyParserTests.swift
@@ -1132,27 +1132,6 @@ final class AccessibilityHierarchyParserTests: XCTestCase {
         XCTAssertEqual(elements, ["child"], "Element should still be parsed even when its container drops it")
     }
 
-    func testParserHandlesTabBarTraitViewWithUnresolvableButtons() {
-        let root = UIView(frame: CGRect(x: 0, y: 0, width: 200, height: 200))
-        let tabBarish = UIView(frame: root.bounds)
-        tabBarish.accessibilityTraits.insert(.tabBar)
-
-        let dangling = UIAccessibilityElement(accessibilityContainer: tabBarish)
-        dangling.accessibilityLabel = "dangling"
-        dangling.accessibilityFrame = CGRect(x: 0, y: 0, width: 10, height: 10)
-        tabBarish.accessibilityElements = [dangling]
-        root.addSubview(tabBarish)
-
-        let parser = AccessibilityHierarchyParser()
-        let elements = parser.parseAccessibilityHierarchy(
-            in: root,
-            userInterfaceLayoutDirectionProvider: TestUserInterfaceLayoutDirectionProvider(userInterfaceLayoutDirection: .leftToRight),
-            userInterfaceIdiomProvider: TestUserInterfaceIdiomProvider(userInterfaceIdiom: .phone)
-        ).flattenToElements().map { $0.description }
-
-        XCTAssertEqual(elements, ["dangling"], "Tab-bar-trait view with unresolvable buttons must not crash the parser")
-    }
-
     // MARK: - Private Helpers
 
     private func parseMarkers(in view: UIView) -> [AccessibilityMarker] {

--- a/Example/UnitTests/AccessibilityHierarchyParserTests.swift
+++ b/Example/UnitTests/AccessibilityHierarchyParserTests.swift
@@ -1092,6 +1092,67 @@ final class AccessibilityHierarchyParserTests: XCTestCase {
         XCTAssertEqual(elements, ["B1", "A1"])
     }
 
+    // MARK: - Inconsistent Hierarchy Resilience
+
+    /// A container that exposes accessibility elements via `accessibilityElements` but reports
+    /// `NSNotFound` when asked for their index. Previously triggered an `assert` inside
+    /// `context(for:from:...)`.
+    private final class InconsistentListContainer: UIView {
+        let child: UIAccessibilityElement
+
+        override init(frame: CGRect) {
+            child = UIAccessibilityElement(accessibilityContainer: NSNull())
+            super.init(frame: frame)
+            child.accessibilityLabel = "child"
+            child.accessibilityFrame = CGRect(x: 0, y: 0, width: 50, height: 50)
+            accessibilityContainerType = .list
+            accessibilityElements = [child]
+        }
+
+        @available(*, unavailable)
+        required init?(coder: NSCoder) { fatalError("not used") }
+
+        override func index(ofAccessibilityElement element: Any) -> Int {
+            return NSNotFound
+        }
+    }
+
+    func testParserReturnsContextlessElementWhenContainerReportsNotFound() {
+        let root = UIView(frame: CGRect(x: 0, y: 0, width: 200, height: 200))
+        let container = InconsistentListContainer(frame: root.bounds)
+        root.addSubview(container)
+
+        let parser = AccessibilityHierarchyParser()
+        let elements = parser.parseAccessibilityHierarchy(
+            in: root,
+            userInterfaceLayoutDirectionProvider: TestUserInterfaceLayoutDirectionProvider(userInterfaceLayoutDirection: .leftToRight),
+            userInterfaceIdiomProvider: TestUserInterfaceIdiomProvider(userInterfaceIdiom: .phone)
+        ).flattenToElements().map { $0.description }
+
+        XCTAssertEqual(elements, ["child"], "Element should still be parsed even when its container drops it")
+    }
+
+    func testParserHandlesTabBarTraitViewWithUnresolvableButtons() {
+        let root = UIView(frame: CGRect(x: 0, y: 0, width: 200, height: 200))
+        let tabBarish = UIView(frame: root.bounds)
+        tabBarish.accessibilityTraits.insert(.tabBar)
+
+        let dangling = UIAccessibilityElement(accessibilityContainer: tabBarish)
+        dangling.accessibilityLabel = "dangling"
+        dangling.accessibilityFrame = CGRect(x: 0, y: 0, width: 10, height: 10)
+        tabBarish.accessibilityElements = [dangling]
+        root.addSubview(tabBarish)
+
+        let parser = AccessibilityHierarchyParser()
+        let elements = parser.parseAccessibilityHierarchy(
+            in: root,
+            userInterfaceLayoutDirectionProvider: TestUserInterfaceLayoutDirectionProvider(userInterfaceLayoutDirection: .leftToRight),
+            userInterfaceIdiomProvider: TestUserInterfaceIdiomProvider(userInterfaceIdiom: .phone)
+        ).flattenToElements().map { $0.description }
+
+        XCTAssertEqual(elements, ["dangling"], "Tab-bar-trait view with unresolvable buttons must not crash the parser")
+    }
+
     // MARK: - Private Helpers
 
     private func parseMarkers(in view: UIView) -> [AccessibilityMarker] {

--- a/Example/UnitTests/AccessibilityHierarchyParserTests.swift
+++ b/Example/UnitTests/AccessibilityHierarchyParserTests.swift
@@ -1132,6 +1132,55 @@ final class AccessibilityHierarchyParserTests: XCTestCase {
         XCTAssertEqual(elements, ["child"], "Element should still be parsed even when its container drops it")
     }
 
+    /// A `UITabBar` with no items previously triggered a modulo-by-zero `precondition` inside
+    /// `context(for:from:...)`. The parser should now skip the tab-bar context for elements under
+    /// such a tab bar without crashing.
+    func testParserHandlesUITabBarWithoutItems() {
+        let root = UIView(frame: CGRect(x: 0, y: 0, width: 200, height: 200))
+        let tabBar = UITabBar(frame: CGRect(x: 0, y: 150, width: 200, height: 50))
+        // No items set — `tabBar.items` is nil, so the parser sees an empty item list.
+
+        let child = UIView(frame: CGRect(x: 0, y: 0, width: 50, height: 50))
+        child.isAccessibilityElement = true
+        child.accessibilityLabel = "orphan"
+        tabBar.addSubview(child)
+
+        root.addSubview(tabBar)
+
+        let parser = AccessibilityHierarchyParser()
+        let elements = parser.parseAccessibilityHierarchy(
+            in: root,
+            userInterfaceLayoutDirectionProvider: TestUserInterfaceLayoutDirectionProvider(userInterfaceLayoutDirection: .leftToRight),
+            userInterfaceIdiomProvider: TestUserInterfaceIdiomProvider(userInterfaceIdiom: .phone)
+        ).flattenToElements().map { $0.description }
+
+        XCTAssertTrue(
+            elements.contains("orphan"),
+            "Element under an itemless UITabBar should still be parsed without tab-bar context"
+        )
+    }
+
+    /// A view whose `accessibilityPath` is an empty `UIBezierPath` previously produced a
+    /// `CGRect.null` bounding box, whose infinite values trapped in downstream `Int(_:)`
+    /// conversions. The parser should fall back to the element's frame for shape and size.
+    func testParserHandlesEmptyAccessibilityPath() {
+        let root = UIView(frame: CGRect(x: 0, y: 0, width: 200, height: 200))
+        let element = ActivationPointTestView(frame: CGRect(x: 10, y: 10, width: 50, height: 50))
+        element.isAccessibilityElement = true
+        element.accessibilityLabel = "emptyPath"
+        element.overriddenPath = UIBezierPath()
+        root.addSubview(element)
+
+        let parser = AccessibilityHierarchyParser()
+        let elements = parser.parseAccessibilityHierarchy(
+            in: root,
+            userInterfaceLayoutDirectionProvider: TestUserInterfaceLayoutDirectionProvider(userInterfaceLayoutDirection: .leftToRight),
+            userInterfaceIdiomProvider: TestUserInterfaceIdiomProvider(userInterfaceIdiom: .phone)
+        ).flattenToElements().map { $0.description }
+
+        XCTAssertEqual(elements, ["emptyPath"], "Element with empty accessibility path should still be parsed")
+    }
+
     // MARK: - Private Helpers
 
     private func parseMarkers(in view: UIView) -> [AccessibilityMarker] {

--- a/Example/UnitTests/UIAccessibilityCustomRotorParsingTests.swift
+++ b/Example/UnitTests/UIAccessibilityCustomRotorParsingTests.swift
@@ -6,6 +6,52 @@ import XCTest
 @testable import AccessibilitySnapshotParser
 
 final class UIAccessibilityCustomRotorParsingTests: XCTestCase {
+    func test_zeroLimitPreservesRotorNameWithoutCollectingResults() {
+        var searchCount = 0
+        let rotor = UIAccessibilityCustomRotor(name: "Errors") { _ in
+            searchCount += 1
+            return .init(targetElement: "error" as NSString, targetRange: nil)
+        }
+
+        let marker = AccessibilityElement.CustomRotor(
+            from: rotor,
+            parentElement: NSObject(),
+            root: UIView(),
+            resultLimit: 0
+        )
+
+        guard let marker else {
+            return XCTFail("Expected custom rotor marker")
+        }
+        XCTAssertEqual(marker.name, "Errors")
+        XCTAssertEqual(marker.resultMarkers, [])
+        XCTAssertEqual(marker.limit, .none)
+        XCTAssertEqual(searchCount, 0)
+    }
+
+    func test_negativeLimitPreservesRotorNameWithoutCollectingResults() {
+        var searchCount = 0
+        let rotor = UIAccessibilityCustomRotor(name: "Errors") { _ in
+            searchCount += 1
+            return .init(targetElement: "error" as NSString, targetRange: nil)
+        }
+
+        let marker = AccessibilityElement.CustomRotor(
+            from: rotor,
+            parentElement: NSObject(),
+            root: UIView(),
+            resultLimit: -1
+        )
+
+        guard let marker else {
+            return XCTFail("Expected custom rotor marker")
+        }
+        XCTAssertEqual(marker.name, "Errors")
+        XCTAssertEqual(marker.resultMarkers, [])
+        XCTAssertEqual(marker.limit, .none)
+        XCTAssertEqual(searchCount, 0)
+    }
+
     func test_collectResults() {
         let strings: [NSString] = ["one", "two", "three", "four", "five"]
 

--- a/Sources/AccessibilitySnapshot/Parser/Swift/Classes/AccessibilityElement.swift
+++ b/Sources/AccessibilitySnapshot/Parser/Swift/Classes/AccessibilityElement.swift
@@ -50,6 +50,11 @@ public struct AccessibilityElement: Equatable, Codable {
         init?(from: UIAccessibilityCustomRotor, parentElement: NSObject, root: UIView, context: AccessibilityHierarchyParser.Context? = nil, resultLimit: Int) {
             guard from.isKnownRotorType else { return nil }
             name = from.displayName(locale: parentElement.accessibilityLanguage)
+            guard resultLimit > 0 else {
+                limit = .none
+                resultMarkers = []
+                return
+            }
             let collected = from.collectAllResults(nextLimit: resultLimit, previousLimit: resultLimit)
             limit = collected.limit
             resultMarkers = collected.results.compactMap { result in

--- a/Sources/AccessibilitySnapshot/Parser/Swift/Classes/AccessibilityHierarchyParser.swift
+++ b/Sources/AccessibilitySnapshot/Parser/Swift/Classes/AccessibilityHierarchyParser.swift
@@ -327,22 +327,20 @@ public final class AccessibilityHierarchyParser {
                 let tabBarButtons = view.allUITabBarButtons()
                 let tabBarItems = tabBar.items ?? []
 
-                // This logic assumes that the UITabBar has the same number of buttons as it does items, and that they
-                // are in the same order. From testing, this seems to always be true, but there may be some cases that
-                // aren't handled properly here.
+                // An unexpected tab bar shape — no items, a button count that isn't a multiple
+                // of the item count, or a button that isn't in our list — should not crash the
+                // process. Skip context for this element instead; it will still be parsed.
                 //
-                // We use modulo instead of equality because iOS 26 tab bars have multiple sets of tab buttons at
-                // different levels in the view hierarchy, so the total count may be a multiple of the item count.
-                precondition(
-                    tabBarButtons.count % tabBarItems.count == 0,
-                    "UITabBar does not have the same number of tab views as tab items."
-                )
-
-                guard let index = tabBarButtons.firstIndex(of: element) else {
-                    fatalError("Can't find tab bar button in UITabBar")
+                // We use modulo instead of equality because iOS 26 tab bars have multiple sets
+                // of tab buttons at different levels in the view hierarchy, so the total count
+                // may be a multiple of the item count.
+                guard !tabBarItems.isEmpty,
+                      tabBarButtons.count % tabBarItems.count == 0,
+                      let index = tabBarButtons.firstIndex(of: element)
+                else {
+                    return nil
                 }
 
-                // Use modulo to get the tab item index since there may be multiple sets of buttons
                 let tabIndex = index % tabBarItems.count
 
                 return .tabBarItem(
@@ -371,8 +369,11 @@ public final class AccessibilityHierarchyParser {
                     viewToElementsMap[view] = accessibleElements
                 }
 
+                guard let index = accessibleElements.firstIndex(of: element) else {
+                    return nil
+                }
                 return .tab(
-                    index: accessibleElements.firstIndex(of: element)! + 1,
+                    index: index + 1,
                     count: accessibleElements.count
                 )
             }
@@ -380,10 +381,11 @@ public final class AccessibilityHierarchyParser {
         case let .accessibilityContainer(container):
             let elementIndex = container.index(ofAccessibilityElement: element)
 
-            assert(
-                elementIndex != NSNotFound,
-                "Element should not have a container as a context provider if it is not an element in that container"
-            )
+            // The container may not actually contain the element if its accessibility tree is in
+            // an inconsistent state. Drop context for this element rather than crashing.
+            guard elementIndex != NSNotFound else {
+                return nil
+            }
 
             if container is UISegmentedControl {
                 return .series(

--- a/Sources/AccessibilitySnapshot/Parser/Swift/Classes/AccessibilityHierarchyParser.swift
+++ b/Sources/AccessibilitySnapshot/Parser/Swift/Classes/AccessibilityHierarchyParser.swift
@@ -564,7 +564,7 @@ extension AccessibilityHierarchyParser {
     /// Returns the shape of the accessibility element in the root view's coordinate space.
     /// VoiceOver prefers an accessibilityPath if available when drawing the bounding box, but the accessibilityFrame is always used for sort order.
     static func accessibilityShape(for element: NSObject, in root: UIView, preferPath: Bool = true) -> AccessibilityMarker.Shape {
-        if let accessibilityPath = element.accessibilityPath, preferPath {
+        if let accessibilityPath = element.accessibilityPath, preferPath, accessibilityPath.hasFiniteBounds {
             return .path(root.convert(accessibilityPath, from: nil))
 
         } else if let element = element as? UIAccessibilityElement, let container = element.accessibilityContainer, !element.accessibilityFrameInContainerSpace.isNull {
@@ -605,8 +605,8 @@ extension AccessibilityHierarchyParser {
             return frame
         }
 
-        if let path = element.accessibilityPath {
-            return path.bounds
+        if let path = element.accessibilityPath, path.hasFiniteBounds {
+            return path.cgPath.boundingBoxOfPath
         }
 
         return frame
@@ -666,6 +666,27 @@ private extension AccessibilityHierarchyParser {
 }
 
 // MARK: -
+
+private extension UIBezierPath {
+    /// True when the path is non-empty and its CGPath bounding box has finite
+    /// origin and size.
+    ///
+    /// `UIBezierPath.bounds` calls `CGPathGetPathBoundingBox`, which returns
+    /// `CGRect.null` (origin `.infinity`) for empty paths and may carry
+    /// non-finite values when callers feed in `.nan`/`.infinity`. Storing
+    /// such a path in `Shape.path` lets those values flow into downstream
+    /// `Int(_:)` conversions and trap with a Swift runtime SIGTRAP. Callers
+    /// gate `.path(...)` on this check and fall back to `.frame(...)`.
+    var hasFiniteBounds: Bool {
+        guard !isEmpty else { return false }
+        let rect = cgPath.boundingBoxOfPath
+        return !rect.isNull
+            && rect.origin.x.isFinite
+            && rect.origin.y.isFinite
+            && rect.size.width.isFinite
+            && rect.size.height.isFinite
+    }
+}
 
 /// Captures container information at node creation time, avoiding the need to re-derive it later.
 private struct ContainerInfo {

--- a/Sources/AccessibilitySnapshot/Parser/Swift/Classes/AccessibilityHierarchyParser.swift
+++ b/Sources/AccessibilitySnapshot/Parser/Swift/Classes/AccessibilityHierarchyParser.swift
@@ -266,7 +266,7 @@ public final class AccessibilityHierarchyParser {
         case .rightToLeft:
             horizontalCompare = (>)
         @unknown default:
-            fatalError("Unknown user interface layout direction: \(userInterfaceLayoutDirection)")
+            horizontalCompare = (<)
         }
 
         // Derived via experimentation, these magic numbers are the cutoff for VoiceOver to consider
@@ -331,9 +331,8 @@ public final class AccessibilityHierarchyParser {
                 // of the item count, or a button that isn't in our list — should not crash the
                 // process. Skip context for this element instead; it will still be parsed.
                 //
-                // We use modulo instead of equality because iOS 26 tab bars have multiple sets
-                // of tab buttons at different levels in the view hierarchy, so the total count
-                // may be a multiple of the item count.
+                // Some UIKit tab bars expose multiple button sets at different levels in the
+                // view hierarchy, so the total count may be a multiple of the item count.
                 guard !tabBarItems.isEmpty,
                       tabBarButtons.count % tabBarItems.count == 0,
                       let index = tabBarButtons.firstIndex(of: element)
@@ -826,12 +825,16 @@ private extension NSObject {
 
     /// The form of context provider the object acts as for elements beneath it in the hierarchy when the elements
     /// beneath it are part of the view hierarchy and the object is not an accessibility container.
-    private func providedContextAsSuperview() -> AccessibilityHierarchyParser.ContextProvider {
+    private func providedContextAsSuperview() -> AccessibilityHierarchyParser.ContextProvider? {
         if accessibilityContainerType == .dataTable, let self = self as? UIAccessibilityContainerDataTable {
             return .dataTable(self)
         }
 
-        return .superview(self as! UIView)
+        guard let view = self as? UIView else {
+            return nil
+        }
+
+        return .superview(view)
     }
 
     /// The form of context provider the object acts as for elements beneath it in the hierarchy when the object is

--- a/Sources/AccessibilitySnapshot/Parser/Swift/Classes/AccessibilityHierarchyParser.swift
+++ b/Sources/AccessibilitySnapshot/Parser/Swift/Classes/AccessibilityHierarchyParser.swift
@@ -1,6 +1,18 @@
 import Accessibility
+import os.log
 import SwiftUI
 import UIKit
+
+/// Surfaces parser resilience events that would previously have crashed the host.
+///
+/// The parser intentionally degrades gracefully when the host's accessibility tree is in an
+/// unexpected shape (mismatched tab bar counts, containers reporting `NSNotFound` for their own
+/// children, degenerate `UIBezierPath`s, etc.). These events are logged here so they remain
+/// visible during development without bringing the process down.
+private let parserLog = OSLog(
+    subsystem: "com.cashapp.AccessibilitySnapshot",
+    category: "Parser"
+)
 
 public protocol UserInterfaceLayoutDirectionProviding {
     var userInterfaceLayoutDirection: UIUserInterfaceLayoutDirection { get }
@@ -270,6 +282,12 @@ public final class AccessibilityHierarchyParser {
         case .rightToLeft:
             horizontalCompare = (>)
         @unknown default:
+            os_log(
+                "Unknown UIUserInterfaceLayoutDirection (%{public}d); falling back to left-to-right ordering.",
+                log: parserLog,
+                type: .error,
+                userInterfaceLayoutDirection.rawValue
+            )
             horizontalCompare = (<)
         }
 
@@ -341,6 +359,13 @@ public final class AccessibilityHierarchyParser {
                       tabBarButtons.count % tabBarItems.count == 0,
                       let index = tabBarButtons.firstIndex(of: element)
                 else {
+                    os_log(
+                        "UITabBar has an unexpected shape (buttons=%{public}d, items=%{public}d); dropping tab-bar context for element.",
+                        log: parserLog,
+                        type: .error,
+                        tabBarButtons.count,
+                        tabBarItems.count
+                    )
                     return nil
                 }
 
@@ -373,6 +398,11 @@ public final class AccessibilityHierarchyParser {
                 }
 
                 guard let index = accessibleElements.firstIndex(of: element) else {
+                    os_log(
+                        "Tab-bar-trait view does not contain the element being parsed; dropping tab context.",
+                        log: parserLog,
+                        type: .error
+                    )
                     return nil
                 }
                 return .tab(
@@ -387,6 +417,11 @@ public final class AccessibilityHierarchyParser {
             // The container may not actually contain the element if its accessibility tree is in
             // an inconsistent state. Drop context for this element rather than crashing.
             guard elementIndex != NSNotFound else {
+                os_log(
+                    "Accessibility container reported NSNotFound for an element it advertises; dropping container context.",
+                    log: parserLog,
+                    type: .error
+                )
                 return nil
             }
 
@@ -856,6 +891,12 @@ private extension NSObject {
         }
 
         guard let view = self as? UIView else {
+            os_log(
+                "Non-UIView object %{public}@ reports providesContext=true but cannot supply superview context; skipping.",
+                log: parserLog,
+                type: .error,
+                String(describing: type(of: self))
+            )
             return nil
         }
 

--- a/Sources/AccessibilitySnapshot/Parser/Swift/Classes/AccessibilityHierarchyParser.swift
+++ b/Sources/AccessibilitySnapshot/Parser/Swift/Classes/AccessibilityHierarchyParser.swift
@@ -102,7 +102,9 @@ public final class AccessibilityHierarchyParser {
     ///
     /// - parameter root: The root view of the accessibility hierarchy. Coordinates in the returned markers will be
     /// relative to this view's coordinate space.
-    /// - parameter rotorResultLimit: Maximum number of rotor results to collect in each direction. Defaults to 10.
+    /// - parameter rotorResultLimit: Maximum number of rotor results to collect in each direction.
+    /// Values less than or equal to 0 include rotor names only and do not evaluate rotor result blocks.
+    /// Defaults to 10.
     /// - parameter userInterfaceLayoutDirectionProvider: The provider of the device's user interface layout direction.
     /// In most cases, this should use the default value, `UIApplication.shared`.
     @available(*, deprecated, message: "Use parseAccessibilityHierarchy(in:) and flattenToElements() instead")
@@ -137,7 +139,9 @@ public final class AccessibilityHierarchyParser {
     /// Use `flattenToElements()` on the result to get the same output as `parseAccessibilityElements`.
     ///
     /// - parameter root: The root view of the accessibility hierarchy
-    /// - parameter rotorResultLimit: Maximum number of rotor results to collect in each direction. Defaults to 10.
+    /// - parameter rotorResultLimit: Maximum number of rotor results to collect in each direction.
+    /// Values less than or equal to 0 include rotor names only and do not evaluate rotor result blocks.
+    /// Defaults to 10.
     /// - parameter userInterfaceLayoutDirectionProvider: Provider of the device's UI layout direction
     /// - parameter userInterfaceIdiomProvider: Provider of the device's interface idiom
     /// - returns: Array of root-level hierarchy nodes with containers grouping their children


### PR DESCRIPTION
## Summary

The parser has several crash sites that fire when the host's accessibility tree has an unexpected shape. None of these are conditions the parser can't recover from — the element can still be parsed, it just doesn't get full context or metadata for that node.

This PR replaces all of them with guards that degrade gracefully and `os_log` an error so unexpected hierarchies still surface during development.

### Crash sites in `context(for:from:...)`

| Site | Crash kind | Fires in `-O`? |
|------|------------|----------------|
| `precondition(tabBarButtons.count % tabBarItems.count == 0, ...)` | `precondition` (also modulo-by-zero when `tabBarItems.count == 0`) | yes |
| `fatalError("Can't find tab bar button in UITabBar")` | `fatalError` | yes |
| `accessibleElements.firstIndex(of: element)! + 1` | force-unwrap | yes |
| `assert(elementIndex != NSNotFound, ...)` | `assert` | no (debug-only) |

### Additional crash sites

| Site | Crash kind | Fix |
|------|------------|-----|
| `assertionFailure` / `precondition` in `recursiveAccessibilityHierarchy` | crash traps in release builds | replaced with guard-return |
| `UIBezierPath.bounds` returning `CGRect.null` for empty paths | `Int()` conversion of infinite values SIGTRAPs | guarded with finite bounds check |
| Rotor search with nonpositive result limit | crash or hang evaluating rotor blocks | treat as metadata-only (collect rotor names without evaluating result blocks) |
| `@unknown default` for `UIUserInterfaceLayoutDirection` | `fatalError` in release | fall back to left-to-right ordering and log |
| `providedContextAsSuperview()` force-cast of non-UIView to `UIView` | force-cast crash | return `nil` and log |

Each soft-fail site logs an error via `OSLog(subsystem: "com.cashapp.AccessibilitySnapshot", category: "Parser")` so unexpected hierarchies are visible in development and Console.app without crashing.

## Test plan

- `testParserReturnsContextlessElementWhenContainerReportsNotFound` — container declaring an element via `accessibilityElements` but answering `NSNotFound` to `index(ofAccessibilityElement:)`. Element is still parsed.
- `testParserHandlesUITabBarWithoutItems` — `UITabBar` with no items previously triggered modulo-by-zero inside `context(for:from:...)`. Element under the tab bar is still parsed without tab-bar context.
- `testParserHandlesEmptyAccessibilityPath` — view exposing an empty `UIBezierPath` as its `accessibilityPath`. The parser falls back to the element's frame instead of trapping on infinite bounds.
- `test_zeroLimitPreservesRotorNameWithoutCollectingResults` / `test_negativeLimitPreservesRotorNameWithoutCollectingResults` — rotor with `resultLimit <= 0` collects rotor names without evaluating result blocks.
- Existing parser tests pass unchanged.