### PR TITLE
Scope viewToElementsMap to parse call lifetime

### DIFF
--- a/Sources/AccessibilitySnapshot/Parser/Swift/Classes/AccessibilityHierarchyParser.swift
+++ b/Sources/AccessibilitySnapshot/Parser/Swift/Classes/AccessibilityHierarchyParser.swift
@@ -160,6 +160,7 @@ public final class AccessibilityHierarchyParser {
             userInterfaceIdiom: userInterfaceIdiom
         )
 
+        var viewToElementsMap: [UIView: [NSObject]] = [:]
         let contextualizedElements = uncontextualizedElements.map { element in
             ContextualElement(
                 object: element.object,
@@ -167,7 +168,8 @@ public final class AccessibilityHierarchyParser {
                     for: element.object,
                     from: element.contextProvider,
                     userInterfaceLayoutDirection: userInterfaceLayoutDirection,
-                    userInterfaceIdiom: userInterfaceIdiom
+                    userInterfaceIdiom: userInterfaceIdiom,
+                    viewToElementsMap: &viewToElementsMap
                 )
             )
         }
@@ -315,7 +317,8 @@ public final class AccessibilityHierarchyParser {
         for element: NSObject,
         from contextProvider: ContextProvider?,
         userInterfaceLayoutDirection: UIUserInterfaceLayoutDirection,
-        userInterfaceIdiom: UIUserInterfaceIdiom
+        userInterfaceIdiom: UIUserInterfaceIdiom,
+        viewToElementsMap: inout [UIView: [NSObject]]
     ) -> Context? {
         guard let contextProvider = contextProvider else {
             return nil
@@ -486,9 +489,6 @@ public final class AccessibilityHierarchyParser {
     }
 
     // MARK: - Private Properties
-
-    /// Used for memoization of accessibility hierarchy parsing when determining element contexts.
-    private var viewToElementsMap: [UIView: [NSObject]] = [:]
 
     // MARK: - Private Hierarchy Methods
 

--- a/Sources/AccessibilitySnapshot/Parser/Swift/Classes/AccessibilityHierarchyParser.swift
+++ b/Sources/AccessibilitySnapshot/Parser/Swift/Classes/AccessibilityHierarchyParser.swift
@@ -488,7 +488,6 @@ public final class AccessibilityHierarchyParser {
         return nil
     }
 
-    // MARK: - Private Properties
 
     // MARK: - Private Hierarchy Methods
 


### PR DESCRIPTION
## Summary

`viewToElementsMap` is currently scoped to the `AccessibilityHierarchyParser` instance. This means every tab bar view and its child `NSObject`s parsed across calls are retained for the lifetime of the parser. When the parser is long-lived, this is a memory leak.

This PR narrows the scope from instance to function. The dictionary is declared as a local in `parseAccessibilityHierarchy(in:)` and passed `inout` to `context(for:from:...)`. Same caching behavior within a single parse call, no retention across calls.

## Changes

- Remove `viewToElementsMap` instance property  
- Declare as local in `parseAccessibilityHierarchy(in:)`, pass `inout` to `context(for:from:...)`

## Test plan

- Existing parser tests pass unchanged — cache behavior within a single parse call is identical