### PR TITLE
Prune views when either frame axis is degenerate

### DIFF
--- a/Example/UnitTests/AccessibilityHierarchyParserTests.swift
+++ b/Example/UnitTests/AccessibilityHierarchyParserTests.swift
@@ -59,7 +59,7 @@ final class AccessibilityHierarchyParserTests: XCTestCase {
         elementA.accessibilityFrame = elementA.frame
         gridView.addSubview(elementA)
 
-        let elementB = UIView(frame: .init(x: 10, y: 0, width: 0, height: 10))
+        let elementB = UIView(frame: .init(x: 10, y: 0, width: 10, height: 10))
         elementB.isAccessibilityElement = true
         elementB.accessibilityLabel = "B"
         elementB.accessibilityFrame = elementB.frame
@@ -100,7 +100,7 @@ final class AccessibilityHierarchyParserTests: XCTestCase {
         let padMagicNumber = 25
 
         elementA.accessibilityFrame = .init(x: 0, y: padMagicNumber, width: 10, height: 10)
-        elementB.accessibilityFrame = .init(x: 10, y: 0, width: 0, height: 10)
+        elementB.accessibilityFrame = .init(x: 10, y: 0, width: 10, height: 10)
         elementC.accessibilityFrame = .init(x: 20, y: -padMagicNumber, width: 10, height: 10)
         elementD.accessibilityFrame = .init(x: 30, y: -padMagicNumber, width: 10, height: 10)
 

--- a/Sources/AccessibilitySnapshot/Parser/Swift/Classes/AccessibilityHierarchyParser.swift
+++ b/Sources/AccessibilitySnapshot/Parser/Swift/Classes/AccessibilityHierarchyParser.swift
@@ -763,24 +763,26 @@ private extension NSObject {
             return []
         }
 
-        // Ignore elements that are views if they are not visible on the screen, either due to visibility, size, or
-        // alpha. VoiceOver actually has some very low alpha threshold at which it will still display an element
-        // (presumably to account for animations and/or rounding error). We use an alpha threshold of zero since that
-        // should fulfill the intent.
-        //
-        // Zero-frame wrappers that clip their bounds or expose explicit accessibility children are pruned, because
-        // their visible content is collapsed. Non-clipping wrapper views with a zero frame are allowed through, because
-        // SwiftUI bridging layers (e.g. _UIInheritedView inside _UIFloatingBarContainerView) use zero-frame wrappers
-        // whose children overflow and are visible. Pruning those hides real accessible content such as the
-        // UISearchBarTextField rendered by .searchable(). For accessibility elements themselves, we additionally prune
-        // anything whose frame is degenerate on either axis (below a sub-pixel threshold), since those have no visible
-        // footprint and would surface as spurious targets.
-        if let `self` = self as? UIView,
-           self.isHidden || self.alpha <= 0
-           || (self.frame.size == .zero && (self.clipsToBounds || self.accessibilityElements != nil))
-           || (self.isAccessibilityElement && (self.frame.width < 0.001 || self.frame.height < 0.001))
-        {
-            return []
+        if let view = self as? UIView {
+            // VoiceOver hides elements that are invisible or fully transparent. (VoiceOver uses
+            // a very low alpha threshold to account for animations; zero is close enough.)
+            let isInvisible = view.isHidden || view.alpha <= 0
+
+            // Zero-frame wrappers that clip or own their accessibility model are collapsed. We
+            // can't prune all zero-frame wrappers because SwiftUI bridging (e.g.
+            // _UIInheritedView in _UIFloatingBarContainerView) uses them as overflow containers
+            // for real content like the UISearchBarTextField from .searchable().
+            let isCollapsedWrapper = view.frame.size == .zero
+                && (view.clipsToBounds || view.accessibilityElements != nil)
+
+            // Leaf accessibility elements with a degenerate frame on either axis have no
+            // visible footprint and would surface as spurious VoiceOver targets.
+            let isDegenerateElement = view.isAccessibilityElement
+                && (abs(view.frame.width) <= 0.001 || abs(view.frame.height) <= 0.001)
+
+            if isInvisible || isCollapsedWrapper || isDegenerateElement {
+                return []
+            }
         }
 
         var recursiveAccessibilityHierarchy: [AccessibilityNode] = []

--- a/Sources/AccessibilitySnapshot/Parser/Swift/Classes/AccessibilityHierarchyParser.swift
+++ b/Sources/AccessibilitySnapshot/Parser/Swift/Classes/AccessibilityHierarchyParser.swift
@@ -768,15 +768,17 @@ private extension NSObject {
         // (presumably to account for animations and/or rounding error). We use an alpha threshold of zero since that
         // should fulfill the intent.
         //
-        // Degenerate-frame views (either axis below a sub-pixel threshold) are pruned when they clip their bounds
-        // (children are invisible), are accessibility elements, or are explicit accessibility containers
-        // (accessibilityElements is set). Degenerate-frame wrapper views that don't clip and only contain subviews are
-        // allowed through, because SwiftUI bridging layers (e.g. _UIInheritedView inside _UIFloatingBarContainerView)
-        // use zero-frame wrappers whose children overflow and are visible. Pruning those hides real accessible content
-        // such as the UISearchBarTextField rendered by .searchable().
+        // Zero-frame wrappers that clip their bounds or expose explicit accessibility children are pruned, because
+        // their visible content is collapsed. Non-clipping wrapper views with a zero frame are allowed through, because
+        // SwiftUI bridging layers (e.g. _UIInheritedView inside _UIFloatingBarContainerView) use zero-frame wrappers
+        // whose children overflow and are visible. Pruning those hides real accessible content such as the
+        // UISearchBarTextField rendered by .searchable(). For accessibility elements themselves, we additionally prune
+        // anything whose frame is degenerate on either axis (below a sub-pixel threshold), since those have no visible
+        // footprint and would surface as spurious targets.
         if let `self` = self as? UIView,
            self.isHidden || self.alpha <= 0
-           || ((self.frame.width < 0.001 || self.frame.height < 0.001) && (self.clipsToBounds || self.isAccessibilityElement || self.accessibilityElements != nil))
+           || (self.frame.size == .zero && (self.clipsToBounds || self.accessibilityElements != nil))
+           || (self.isAccessibilityElement && (self.frame.width < 0.001 || self.frame.height < 0.001))
         {
             return []
         }

--- a/Sources/AccessibilitySnapshot/Parser/Swift/Classes/AccessibilityHierarchyParser.swift
+++ b/Sources/AccessibilitySnapshot/Parser/Swift/Classes/AccessibilityHierarchyParser.swift
@@ -768,17 +768,16 @@ private extension NSObject {
             // a very low alpha threshold to account for animations; zero is close enough.)
             let isInvisible = view.isHidden || view.alpha <= 0
 
-            // Zero-frame wrappers that clip or own their accessibility model are collapsed. We
-            // can't prune all zero-frame wrappers because SwiftUI bridging (e.g.
+            // Empty-frame wrappers that clip or own their accessibility model are collapsed. We
+            // can't prune all empty-frame wrappers because SwiftUI bridging (e.g.
             // _UIInheritedView in _UIFloatingBarContainerView) uses them as overflow containers
             // for real content like the UISearchBarTextField from .searchable().
-            let isCollapsedWrapper = view.frame.size == .zero
+            let isCollapsedWrapper = view.frame.isEmpty
                 && (view.clipsToBounds || view.accessibilityElements != nil)
 
-            // Leaf accessibility elements with a degenerate frame on either axis have no
-            // visible footprint and would surface as spurious VoiceOver targets.
-            let isDegenerateElement = view.isAccessibilityElement
-                && (abs(view.frame.width) <= 0.001 || abs(view.frame.height) <= 0.001)
+            // Leaf accessibility elements with an empty frame have no visible footprint and
+            // would surface as spurious VoiceOver targets.
+            let isDegenerateElement = view.isAccessibilityElement && view.frame.isEmpty
 
             if isInvisible || isCollapsedWrapper || isDegenerateElement {
                 return []

--- a/Sources/AccessibilitySnapshot/Parser/Swift/Classes/AccessibilityHierarchyParser.swift
+++ b/Sources/AccessibilitySnapshot/Parser/Swift/Classes/AccessibilityHierarchyParser.swift
@@ -528,7 +528,6 @@ public final class AccessibilityHierarchyParser {
         return nil
     }
 
-
     // MARK: - Private Hierarchy Methods
 
     private func mapNodesToHierarchy(
@@ -769,15 +768,15 @@ private extension NSObject {
         // (presumably to account for animations and/or rounding error). We use an alpha threshold of zero since that
         // should fulfill the intent.
         //
-        // Zero-frame views are pruned when they clip their bounds (children are invisible), are accessibility
-        // elements, or are explicit accessibility containers (accessibilityElements is set). Zero-frame wrapper views
-        // that don't clip and only contain subviews are allowed through, because SwiftUI bridging layers (e.g.
-        // _UIInheritedView inside _UIFloatingBarContainerView) use zero-frame wrappers whose children overflow and
-        // are visible. Pruning those hides real accessible content such as the UISearchBarTextField rendered by
-        // .searchable().
+        // Degenerate-frame views (either axis below a sub-pixel threshold) are pruned when they clip their bounds
+        // (children are invisible), are accessibility elements, or are explicit accessibility containers
+        // (accessibilityElements is set). Degenerate-frame wrapper views that don't clip and only contain subviews are
+        // allowed through, because SwiftUI bridging layers (e.g. _UIInheritedView inside _UIFloatingBarContainerView)
+        // use zero-frame wrappers whose children overflow and are visible. Pruning those hides real accessible content
+        // such as the UISearchBarTextField rendered by .searchable().
         if let `self` = self as? UIView,
            self.isHidden || self.alpha <= 0
-           || (self.frame.size == .zero && (self.clipsToBounds || self.isAccessibilityElement || self.accessibilityElements != nil))
+           || ((self.frame.width < 0.001 || self.frame.height < 0.001) && (self.clipsToBounds || self.isAccessibilityElement || self.accessibilityElements != nil))
         {
             return []
         }


### PR DESCRIPTION
## Summary
The view-pruning gate in `recursiveAccessibilityHierarchy` checked `frame.size == .zero`, which only matched when **both** width and height were zero. Slivers with one axis at zero (e.g. width 0, height 100) slipped through and surfaced as elements with no visible footprint.

Switch the check to compare each axis independently — prune when **either** `frame.width` or `frame.height` is below a sub-pixel threshold (`0.001`). This catches single-axis collapses and float-layout slivers in addition to exact zero.

## Test plan
- [ ] Existing snapshot/unit tests pass
- [ ] Verify a view with a zero-width-but-nonzero-height frame is no longer surfaced as an accessibility element