### PR TITLE
Separate traversal from representation with generic fold

### DIFF
--- a/Example/UnitTests/AccessibilityHierarchyParserTests.swift
+++ b/Example/UnitTests/AccessibilityHierarchyParserTests.swift
@@ -942,9 +942,6 @@ final class AccessibilityHierarchyParserTests: XCTestCase {
         XCTAssertEqual(elements, ["emptyPath"], "Element with empty accessibility path should still be parsed")
     }
 
-    /// A non-finite `accessibilityFrame` must not produce a non-finite shape: JSON cannot represent
-    /// NaN/±Infinity, so an unguarded shape would make `JSONEncoder` throw. The parser sanitizes the
-    /// geometry at the UIKit → model boundary, falling back to a zero frame.
     func testParserProducesEncodableShapeForNonFiniteFrame() throws {
         let root = UIView(frame: CGRect(x: 0, y: 0, width: 100, height: 100))
         let element = ActivationPointTestView(frame: CGRect(x: 10, y: 10, width: 50, height: 50))
@@ -956,6 +953,44 @@ final class AccessibilityHierarchyParserTests: XCTestCase {
         let marker = try XCTUnwrap(parseMarkers(in: root).first)
         XCTAssertEqual(marker.shape, .frame(.zero), "A non-finite frame should fall back to a zero frame")
         XCTAssertNoThrow(try JSONEncoder().encode(marker.shape), "The produced shape must be JSON-encodable")
+    }
+
+    // MARK: - Generic Fold Tests
+
+    func testGenericFoldPassesSourceObjects() {
+        let rootView = UIView(frame: .init(x: 0, y: 0, width: 100, height: 100))
+
+        let container = UIView(frame: .init(x: 0, y: 0, width: 100, height: 100))
+        container.accessibilityContainerType = .list
+        rootView.addSubview(container)
+
+        let element = UIView(frame: .init(x: 10, y: 10, width: 30, height: 30))
+        element.isAccessibilityElement = true
+        element.accessibilityLabel = "Item"
+        element.accessibilityFrame = CGRect(x: 10, y: 10, width: 30, height: 30)
+        container.addSubview(element)
+
+        typealias FoldNode = (label: String, source: NSObject, container: AccessibilityContainer?)
+
+        let parser = AccessibilityHierarchyParser()
+        let nodes: [FoldNode] = parser.parseAccessibilityHierarchy(
+            in: rootView,
+            userInterfaceLayoutDirectionProvider: TestUserInterfaceLayoutDirectionProvider(
+                userInterfaceLayoutDirection: .leftToRight
+            ),
+            userInterfaceIdiomProvider: TestUserInterfaceIdiomProvider(userInterfaceIdiom: .phone),
+            makeElement: { elem, index, source in
+                (label: elem.description, source: source, container: nil)
+            },
+            makeContainer: { cont, children, source in
+                (label: "container", source: source, container: cont)
+            }
+        )
+
+        XCTAssertEqual(nodes.count, 1)
+        let listNode = nodes[0]
+        XCTAssertTrue(listNode.source === container)
+        XCTAssertNotNil(listNode.container)
     }
 
     // MARK: - Private Helpers

--- a/Sources/AccessibilitySnapshot/Parser/Swift/Classes/AccessibilityHierarchyParser.swift
+++ b/Sources/AccessibilitySnapshot/Parser/Swift/Classes/AccessibilityHierarchyParser.swift
@@ -163,6 +163,26 @@ public final class AccessibilityHierarchyParser {
         userInterfaceLayoutDirectionProvider: UserInterfaceLayoutDirectionProviding = UIApplication.shared,
         userInterfaceIdiomProvider: UserInterfaceIdiomProviding = UIDevice.current
     ) -> [AccessibilityHierarchy] {
+        parseAccessibilityHierarchy(
+            in: root,
+            rotorResultLimit: rotorResultLimit,
+            userInterfaceLayoutDirectionProvider: userInterfaceLayoutDirectionProvider,
+            userInterfaceIdiomProvider: userInterfaceIdiomProvider,
+            makeElement: { element, traversalIndex, _ in .element(element, traversalIndex: traversalIndex) },
+            makeContainer: { container, children, _ in .container(container, children: children) }
+        )
+    }
+
+    /// Folds the parsed accessibility tree into a caller-defined node type in a single traversal.
+    /// `source` exposes the live accessibility object that produced each element or container.
+    public func parseAccessibilityHierarchy<Node>(
+        in root: UIView,
+        rotorResultLimit: Int = AccessibilityElement.defaultRotorResultLimit,
+        userInterfaceLayoutDirectionProvider: UserInterfaceLayoutDirectionProviding = UIApplication.shared,
+        userInterfaceIdiomProvider: UserInterfaceIdiomProviding = UIDevice.current,
+        makeElement: (AccessibilityElement, _ traversalIndex: Int, _ source: NSObject) -> Node,
+        makeContainer: (AccessibilityContainer, _ children: [Node], _ source: NSObject) -> Node
+    ) -> [Node] {
         let userInterfaceLayoutDirection = userInterfaceLayoutDirectionProvider.userInterfaceLayoutDirection
         let userInterfaceIdiom = userInterfaceIdiomProvider.userInterfaceIdiom
 
@@ -194,7 +214,14 @@ public final class AccessibilityHierarchyParser {
             buildElement(from: element.object, context: element.context, in: root, rotorResultLimit: rotorResultLimit)
         }
 
-        return mapNodesToHierarchy(accessibilityNodes, sortedElements: uncontextualizedElements, elements: elements, in: root)
+        return foldNodes(
+            accessibilityNodes,
+            sortedElements: uncontextualizedElements,
+            elements: elements,
+            in: root,
+            makeElement: makeElement,
+            makeContainer: makeContainer
+        )
     }
 
     // MARK: - Private Types
@@ -530,23 +557,25 @@ public final class AccessibilityHierarchyParser {
 
     // MARK: - Private Hierarchy Methods
 
-    private func mapNodesToHierarchy(
+    private func foldNodes<Node>(
         _ nodes: [AccessibilityNode],
         sortedElements: [(object: NSObject, contextProvider: ContextProvider?)],
         elements: [AccessibilityElement],
-        in root: UIView
-    ) -> [AccessibilityHierarchy] {
+        in root: UIView,
+        makeElement: (AccessibilityElement, _ traversalIndex: Int, _ source: NSObject) -> Node,
+        makeContainer: (AccessibilityContainer, _ children: [Node], _ source: NSObject) -> Node
+    ) -> [Node] {
         var indexLookup: [ObjectIdentifier: Int] = [:]
         for (index, element) in sortedElements.enumerated() {
             indexLookup[ObjectIdentifier(element.object)] = index
         }
 
-        func mapNode(_ node: AccessibilityNode) -> [AccessibilityHierarchy] {
+        func mapNode(_ node: AccessibilityNode) -> [(node: Node, sortIndex: Int)] {
             switch node {
             case let .element(object, _):
                 guard let index = indexLookup[ObjectIdentifier(object)],
                       index < elements.count else { return [] }
-                return [.element(elements[index], traversalIndex: index)]
+                return [(makeElement(elements[index], index, object), index)]
 
             case let .group(children, _, _, containerInfo):
                 let mappedChildren = children.flatMap { mapNode($0) }.sorted { lhs, rhs in
@@ -580,14 +609,15 @@ public final class AccessibilityHierarchyParser {
                         type: containerType,
                         frame: frame
                     )
-                    return [.container(container, children: mappedChildren)]
+                    let sortIndex = mappedChildren.map { $0.sortIndex }.min() ?? Int.max
+                    return [(makeContainer(container, mappedChildren.map { $0.node }, info.view), sortIndex)]
                 }
 
                 return mappedChildren
             }
         }
 
-        return nodes.flatMap { mapNode($0) }
+        return nodes.flatMap { mapNode($0) }.map { $0.node }
     }
 }
 


### PR DESCRIPTION
## Summary

Separates the tree traversal from the output representation by making `mapNodesToHierarchy` generic.

```
Before:  walk → AccessibilityNode tree → mapNodesToHierarchy() → [AccessibilityHierarchy]

After:   walk → AccessibilityNode tree → foldNodes<Node>()     → [Node]
                                          ├── makeElement(element, index, source) → Node
                                          └── makeContainer(container, children, source) → Node
```

`parseAccessibilityHierarchy(in:)` becomes a two-line wrapper that calls the fold with closures producing `AccessibilityHierarchy`. No behavioral change for existing callers.

## Usage

```swift
parser.parseAccessibilityHierarchy(
    in: view,
    makeElement: { element, traversalIndex, source in
        MyNode.leaf(element, view: source)
    },
    makeContainer: { container, children, source in
        MyNode.group(container, children: children, view: source)
    }
)
```

`source` is the live `NSObject` that produced the element or container.
