### PR TITLE
Fall back to UIAccessibilityContainer index APIs when accessibilityElements is nil

### DIFF
--- a/Example/UnitTests/AccessibilityHierarchyParserTests.swift
+++ b/Example/UnitTests/AccessibilityHierarchyParserTests.swift
@@ -993,6 +993,126 @@ final class AccessibilityHierarchyParserTests: XCTestCase {
         XCTAssertNotNil(listNode.container)
     }
 
+    // MARK: - UIAccessibilityContainer Index API Fallback
+
+    /// A non-`UIView` `NSObject` that vends elements via the index-based container APIs
+    /// (`accessibilityElementCount()` / `accessibilityElement(at:)`) while leaving
+    /// `accessibilityElements` nil should have its elements resolved through that fallback.
+    func testNonViewContainerResolvesElementsViaIndexAPIs() {
+        let rootView = UIView(frame: .init(x: 0, y: 0, width: 200, height: 100))
+
+        let child1 = UIAccessibilityElement(accessibilityContainer: rootView)
+        child1.accessibilityLabel = "Index Child 1"
+        child1.accessibilityFrame = CGRect(x: 0, y: 0, width: 200, height: 40)
+
+        let child2 = UIAccessibilityElement(accessibilityContainer: rootView)
+        child2.accessibilityLabel = "Index Child 2"
+        child2.accessibilityFrame = CGRect(x: 0, y: 50, width: 200, height: 40)
+
+        // The container leaves `accessibilityElements` nil and only implements the index APIs.
+        let container = IndexAPIContainer(elements: [child1, child2])
+        rootView.accessibilityElements = [container]
+
+        let parser = AccessibilityHierarchyParser()
+        let elements = parser.parseAccessibilityHierarchy(
+            in: rootView,
+            userInterfaceLayoutDirectionProvider: TestUserInterfaceLayoutDirectionProvider(userInterfaceLayoutDirection: .leftToRight),
+            userInterfaceIdiomProvider: TestUserInterfaceIdiomProvider(userInterfaceIdiom: .phone)
+        ).flattenToElements().map { $0.description }
+
+        XCTAssertEqual(elements, ["Index Child 1", "Index Child 2"])
+    }
+
+    /// `accessibilityElementCount()` returns `NSNotFound` (== `NSIntegerMax`) for objects that
+    /// don't actually implement the dynamic container methods. The parser must treat that sentinel
+    /// as "no elements" rather than iterating ~`NSIntegerMax` times. This test would hang if the
+    /// guard were removed, so it doubles as a regression test for the sentinel handling.
+    func testNonViewContainerWithNSNotFoundCountIsTreatedAsEmpty() {
+        let rootView = UIView(frame: .init(x: 0, y: 0, width: 200, height: 100))
+
+        let child = UIAccessibilityElement(accessibilityContainer: rootView)
+        child.accessibilityLabel = "Should Not Appear"
+        child.accessibilityFrame = CGRect(x: 0, y: 0, width: 200, height: 40)
+
+        // Report the `NSNotFound` sentinel even though an element technically exists.
+        let container = IndexAPIContainer(elements: [child], reportedCount: NSNotFound)
+        rootView.accessibilityElements = [container]
+
+        let parser = AccessibilityHierarchyParser()
+        let elements = parser.parseAccessibilityHierarchy(
+            in: rootView,
+            userInterfaceLayoutDirectionProvider: TestUserInterfaceLayoutDirectionProvider(userInterfaceLayoutDirection: .leftToRight),
+            userInterfaceIdiomProvider: TestUserInterfaceIdiomProvider(userInterfaceIdiom: .phone)
+        ).flattenToElements().map { $0.description }
+
+        XCTAssertTrue(elements.isEmpty, "Expected the NSNotFound count to be treated as no elements, got: \(elements)")
+    }
+
+    func testContainerWithZeroCountIsTreatedAsEmpty() {
+        let rootView = UIView(frame: .init(x: 0, y: 0, width: 200, height: 100))
+
+        let container = IndexAPIContainer(elements: [], reportedCount: 0)
+        rootView.accessibilityElements = [container]
+
+        let parser = AccessibilityHierarchyParser()
+        let elements = parser.parseAccessibilityHierarchy(
+            in: rootView,
+            userInterfaceLayoutDirectionProvider: TestUserInterfaceLayoutDirectionProvider(userInterfaceLayoutDirection: .leftToRight),
+            userInterfaceIdiomProvider: TestUserInterfaceIdiomProvider(userInterfaceIdiom: .phone)
+        ).flattenToElements().map { $0.description }
+
+        XCTAssertTrue(elements.isEmpty, "Expected zero count to be treated as no elements, got: \(elements)")
+    }
+
+    /// A `UIView` that exposes its children only through the index-based container APIs (nil
+    /// `accessibilityElements`) is resolved through that fallback. Because the view vends elements
+    /// through the index APIs, those take precedence over subview traversal (the parser enters the
+    /// explicit-elements branch and skips the subview branch).
+    func testViewContainerResolvesElementsViaIndexAPIs() {
+        let rootView = IndexAPIView(frame: .init(x: 0, y: 0, width: 200, height: 100))
+
+        // A subview that the subview-iteration branch would otherwise surface. Since the view vends
+        // elements through the index APIs, the index-vended phantom takes precedence instead.
+        let realSubview = UIView(frame: .init(x: 0, y: 0, width: 200, height: 40))
+        realSubview.isAccessibilityElement = true
+        realSubview.accessibilityLabel = "Real Subview"
+        realSubview.accessibilityFrame = CGRect(x: 0, y: 0, width: 200, height: 40)
+        rootView.addSubview(realSubview)
+
+        let parser = AccessibilityHierarchyParser()
+        let elements = parser.parseAccessibilityHierarchy(
+            in: rootView,
+            userInterfaceLayoutDirectionProvider: TestUserInterfaceLayoutDirectionProvider(userInterfaceLayoutDirection: .leftToRight),
+            userInterfaceIdiomProvider: TestUserInterfaceIdiomProvider(userInterfaceIdiom: .phone)
+        ).flattenToElements().map { $0.description }
+
+        XCTAssertEqual(elements, ["Phantom Element"])
+    }
+
+    /// End-to-end regression guard for a real `UISegmentedControl`. It vends its segments through
+    /// `accessibilityElements` (resolved by the first branch of `resolvedAccessibilityElements()`),
+    /// so it must continue to parse as a three-element series with VoiceOver-style "N of 3" context —
+    /// the `accessibilityElements` path must not be disturbed by the index-API fallback.
+    func testSegmentedControlParsesAsSeries() {
+        let window = UIWindow(frame: .init(x: 0, y: 0, width: 320, height: 200))
+        let segmented = UISegmentedControl(items: ["One", "Two", "Three"])
+        segmented.frame = .init(x: 0, y: 0, width: 320, height: 40)
+        window.addSubview(segmented)
+        window.makeKeyAndVisible()
+        window.layoutIfNeeded()
+
+        let markers = parseMarkers(in: window)
+
+        XCTAssertEqual(markers.map { $0.label }, ["One", "Two", "Three"])
+        XCTAssertEqual(markers.map { $0.description }, [
+            "One. Button. 1 of 3.",
+            "Two. Button. 2 of 3.",
+            "Three. Button. 3 of 3.",
+        ])
+
+        window.isHidden = true
+    }
+
     // MARK: - Private Helpers
 
     private func parseMarkers(in view: UIView) -> [AccessibilityMarker] {
@@ -1032,6 +1152,53 @@ private final class ActivationPointTestView: UIView {
 
 private struct TestUserInterfaceLayoutDirectionProvider: UserInterfaceLayoutDirectionProviding {
     var userInterfaceLayoutDirection: UIUserInterfaceLayoutDirection
+}
+
+// MARK: - UIAccessibilityContainer Index API Test Helpers
+
+/// A non-`UIView` `NSObject` that acts as a `UIAccessibilityContainer` purely through the
+/// index-based APIs, leaving `accessibilityElements` nil. `reportedCount` can diverge from the
+/// backing array to exercise sentinel handling such as `NSNotFound`.
+private final class IndexAPIContainer: NSObject {
+    private let elements: [Any]
+    private let reportedCount: Int
+
+    init(elements: [Any], reportedCount: Int? = nil) {
+        self.elements = elements
+        self.reportedCount = reportedCount ?? elements.count
+        super.init()
+    }
+
+    override func accessibilityElementCount() -> Int {
+        return reportedCount
+    }
+
+    override func accessibilityElement(at index: Int) -> Any? {
+        guard index >= 0, index < elements.count else {
+            return nil
+        }
+        return elements[index]
+    }
+}
+
+/// A `UIView` subclass with nil `accessibilityElements` that vends a uniquely-labelled "phantom"
+/// element through the index-based container APIs — the view-shaped equivalent of `IndexAPIContainer`.
+/// The distinct phantom label makes the fallback observable: when the parser resolves a view through
+/// the index APIs, "Phantom Element" surfaces in place of any subview.
+private final class IndexAPIView: UIView {
+    private lazy var phantomElement: UIAccessibilityElement = {
+        let element = UIAccessibilityElement(accessibilityContainer: self)
+        element.accessibilityLabel = "Phantom Element"
+        return element
+    }()
+
+    override func accessibilityElementCount() -> Int {
+        return 1
+    }
+
+    override func accessibilityElement(at index: Int) -> Any? {
+        return index == 0 ? phantomElement : nil
+    }
 }
 
 private struct TestUserInterfaceIdiomProvider: UserInterfaceIdiomProviding {

--- a/Sources/AccessibilitySnapshot/Parser/Swift/Classes/AccessibilityHierarchyParser.swift
+++ b/Sources/AccessibilitySnapshot/Parser/Swift/Classes/AccessibilityHierarchyParser.swift
@@ -819,9 +819,11 @@ private extension NSObject {
         // _UIInheritedView inside _UIFloatingBarContainerView) use zero-frame wrappers whose children overflow and
         // are visible. Pruning those hides real accessible content such as the UISearchBarTextField rendered by
         // .searchable().
+        let explicitAccessibilityElements = resolvedAccessibilityElements()
+
         if let `self` = self as? UIView,
            self.isHidden || self.alpha <= 0
-           || (self.frame.size == .zero && (self.clipsToBounds || self.isAccessibilityElement || self.accessibilityElements != nil))
+           || (self.frame.size == .zero && (self.clipsToBounds || self.isAccessibilityElement || explicitAccessibilityElements != nil))
         {
             return []
         }
@@ -831,7 +833,7 @@ private extension NSObject {
         if isAccessibilityElement {
             recursiveAccessibilityHierarchy.append(.element(self, contextProvider: contextProvider))
 
-        } else if let accessibilityElements = accessibilityElements as? [NSObject] {
+        } else if let accessibilityElements = explicitAccessibilityElements {
             var accessibilityHierarchyOfElements: [AccessibilityNode] = []
             for element in accessibilityElements {
                 accessibilityHierarchyOfElements.append(
@@ -880,6 +882,45 @@ private extension NSObject {
         }
 
         return recursiveAccessibilityHierarchy
+    }
+
+    /// Returns the explicit accessibility elements exposed by this object. When
+    /// `accessibilityElements` is set (including to an empty array) it is used directly — this covers
+    /// UIKit containers such as `UISegmentedControl`, which populate `accessibilityElements` with
+    /// their internal elements. When it is `nil`, this falls back to the `accessibilityElementCount()`
+    /// / `accessibilityElement(at:)` container APIs, mirroring how `UIAccessibilityContainer`
+    /// consumers resolve elements — so an object whose children are exposed only through those APIs
+    /// is captured rather than treated as a leaf. The `NSNotFound` sentinel and a non-positive count
+    /// are filtered below, which is what keeps objects that don't implement the dynamic container
+    /// methods on the caller's existing traversal path: they report `NSNotFound` from
+    /// `accessibilityElementCount()`. Returns `nil` when the object does not act as an explicit
+    /// accessibility container.
+    private func resolvedAccessibilityElements() -> [NSObject]? {
+        if let elements = accessibilityElements as? [NSObject] {
+            return elements
+        }
+
+        // `accessibilityElementCount()` defaults to `NSNotFound` for objects that don't implement the
+        // dynamic container methods (its default is undocumented, but its siblings
+        // `accessibilityElement(at:)` and `index(ofAccessibilityElement:)` document `nil` / `NSNotFound`
+        // defaults, and `NSNotFound` is what UIKit returns on iOS 17+). Treating that sentinel as a real
+        // count would iterate ~`NSIntegerMax` times, so guard against it explicitly.
+        let count = accessibilityElementCount()
+        guard count > 0, count != NSNotFound else {
+            return nil
+        }
+
+        var elements: [NSObject] = []
+        elements.reserveCapacity(count)
+        for index in 0 ..< count {
+            // `accessibilityElement(at:)` may return `nil` (or a non-`NSObject`) for individual indices even
+            // when `accessibilityElementCount()` reports a larger count; those are skipped rather than treated
+            // as a hard error, mirroring how a consumer iterating the container would tolerate gaps.
+            if let element = accessibilityElement(at: index) as? NSObject {
+                elements.append(element)
+            }
+        }
+        return elements.isEmpty ? nil : elements
     }
 
     private func containerInfo(for view: UIView) -> ContainerInfo? {


### PR DESCRIPTION
## Summary

Falls back to the `UIAccessibilityContainer` index APIs (`accessibilityElementCount()` / `accessibilityElement(at:)`) when `accessibilityElements` returns nil.

Some containers vend their children only through the index-based container APIs, returning nil from `accessibilityElements`. The parser previously treated these as having no explicit elements and fell through to subview traversal, missing the container-vended children. This change mirrors the behavior of UIKit's own accessibility tree walker, which uses the index APIs for any object that reports a valid count — including UIViews.

## How it works

`resolvedAccessibilityElements()` checks `accessibilityElements` first. If nil, it iterates `accessibilityElement(at:)` up to `accessibilityElementCount()`. Objects that report `NSNotFound` from `accessibilityElementCount()` (the default) fall through unchanged — their existing traversal path (subview iteration with grouping, sorting, and pruning) is preserved.

In practice, no standard UIKit UIView uses the index API without also setting `accessibilityElements` — UITableView, UICollectionView, UIScrollView, etc. all report either `NSNotFound` or count=0 with nil elements. The fallback primarily captures non-UIView containers (e.g. `UIAccessibilityElement` subclasses) that implement the dynamic container methods.

## Validation

Validated against `_accessibilityLeafDescendantsWithOptions:` (UIKit's internal tree walker) with default options, VoiceOver options, and scanner groups mode. All three confirm the index API takes precedence over subview traversal when implemented.

## Changes

- Add `resolvedAccessibilityElements()` on `NSObject` — tries `accessibilityElements`, falls back to index APIs, filters `NSNotFound` and non-positive count sentinels
- Tests for index-API fallback (both UIView and non-UIView), `NSNotFound` sentinel, zero-count, `UISegmentedControl` end-to-end, and `UIView` container resolution