### PR TITLE
Add visionOS support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,15 +8,23 @@ on:
 
 jobs:
   spm:
-    name: SPM Build
-    runs-on: macOS-14
+    name: SPM Build (${{ matrix.platform }})
+    runs-on: ${{ matrix.runner }}
     strategy:
       matrix:
-        platform: ['iOS_17']
+        include:
+          - platform: iOS_17
+            runner: macOS-14
+          - platform: visionOS_26
+            runner: macOS-15
+            xcode-version: '26.2'
       fail-fast: false
     steps:
       - name: Checkout Repo
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # ratchet:actions/checkout@v4
+      - name: Select Xcode Version
+        if: matrix.xcode-version
+        run: sudo xcode-select -s /Applications/Xcode_${{ matrix.xcode-version }}.app
       - name: Prepare Simulator Runtimes
         run: Scripts/github/prepare-simulators.sh ${{ matrix.platform }}
       - name: Build

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.3
+// swift-tools-version:5.9
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -9,6 +9,7 @@ let package = Package(
     platforms: [
         .iOS(.v13),
         .macOS(.v10_15),
+        .visionOS(.v1),
     ],
     products: [
         // Core + SnapshotTesting for image comparison
@@ -39,12 +40,10 @@ let package = Package(
     dependencies: [
         .package(path: "AccessibilitySnapshotModel"),
         .package(
-            name: "iOSSnapshotTestCase",
             url: "https://github.com/uber/ios-snapshot-test-case.git",
             .upToNextMajor(from: "8.0.0")
         ),
         .package(
-            name: "SnapshotTesting",
             url: "https://github.com/pointfreeco/swift-snapshot-testing.git",
             .upToNextMajor(from: "1.10.0")
         ),
@@ -80,7 +79,7 @@ let package = Package(
                 "AccessibilitySnapshotCore",
                 "AccessibilitySnapshotParser-ObjC",
                 "AccessibilitySnapshotPreviews",
-                "SnapshotTesting",
+                .product(name: "SnapshotTesting", package: "swift-snapshot-testing"),
             ],
             path: "Sources/AccessibilitySnapshot/SnapshotTesting"
         ),
@@ -90,13 +89,17 @@ let package = Package(
                 "AccessibilitySnapshotCore",
                 "AccessibilitySnapshotParser-ObjC",
                 "AccessibilitySnapshotPreviews",
-                "iOSSnapshotTestCase",
+                .product(name: "iOSSnapshotTestCase", package: "ios-snapshot-test-case"),
             ],
             path: "Sources/AccessibilitySnapshot/iOSSnapshotTestCase/Swift"
         ),
         .target(
             name: "FBSnapshotTestCase-Accessibility-ObjC",
-            dependencies: ["AccessibilitySnapshotCore", "iOSSnapshotTestCase", "FBSnapshotTestCase-Accessibility"],
+            dependencies: [
+                "AccessibilitySnapshotCore",
+                .product(name: "iOSSnapshotTestCase", package: "ios-snapshot-test-case"),
+                "FBSnapshotTestCase-Accessibility",
+            ],
             path: "Sources/AccessibilitySnapshot/iOSSnapshotTestCase/ObjC"
         ),
     ]

--- a/README.md
+++ b/README.md
@@ -137,8 +137,17 @@ You can also run accessibility snapshot tests from Objective-C:
 
 ## Requirements
 
-* Xcode 13.2.1 or later
+* Xcode 15.0 or later (the package requires Swift tools 5.9)
 * iOS 13.0 or later
+
+The `AccessibilitySnapshotParser`, `AccessibilitySnapshotCore`, and
+`AccessibilitySnapshotPreviews` products also build for visionOS 1.0 or later, so the
+hierarchy parsing and legend rendering can be used there directly. The
+`AccessibilitySnapshot` product's `Snapshotting` strategies are available on iOS only, since
+[swift-snapshot-testing](https://github.com/pointfreeco/swift-snapshot-testing) vends its
+UIKit image strategies on iOS and tvOS only. The `FBSnapshotTestCase-Accessibility` products
+are iOS only, as
+[ios-snapshot-test-case](https://github.com/uber/ios-snapshot-test-case) supports iOS only.
 
 ## Contributing
 

--- a/Scripts/build.swift
+++ b/Scripts/build.swift
@@ -49,6 +49,7 @@ enum Platform: String, CustomStringConvertible {
     case iOS_17
     case iOS_18
     case iOS_26
+    case visionOS_26
 
     var destination: String {
         switch self {
@@ -58,6 +59,18 @@ enum Platform: String, CustomStringConvertible {
             return "platform=iOS Simulator,OS=18.5,name=iPhone 16 Pro"
         case .iOS_26:
             return "platform=iOS Simulator,OS=26.2,name=iPhone 17 Pro"
+        case .visionOS_26:
+            // The visionOS destination is build-only, so it doesn't pin a specific simulator device.
+            return "generic/platform=visionOS Simulator"
+        }
+    }
+
+    var sdk: String {
+        switch self {
+        case .iOS_17, .iOS_18, .iOS_26:
+            return "iphonesimulator"
+        case .visionOS_26:
+            return "xrsimulator"
         }
     }
 
@@ -146,7 +159,7 @@ if let workspace = task.workspace {
 xcodeBuildArguments.append(
     contentsOf: [
         "-scheme", task.scheme,
-        "-sdk", "iphonesimulator",
+        "-sdk", platform.sdk,
         "-PBXBuildsContinueAfterErrors=0",
         "-destination", platform.destination,
         "-derivedDataPath", platform.derivedDataPath,

--- a/Sources/AccessibilitySnapshot/AccessibilitySnapshotPreviews/SwiftUIAccessibilitySnapshotView.swift
+++ b/Sources/AccessibilitySnapshot/AccessibilitySnapshotPreviews/SwiftUIAccessibilitySnapshotView.swift
@@ -25,7 +25,7 @@ public struct AccessibilitySnapshotView<Content: View>: View {
         self.content = content()
         self.configuration = configuration
         self.palette = palette
-        self.renderSize = renderSize ?? UIScreen.main.bounds.size
+        self.renderSize = renderSize ?? SnapshotPlatformDefaults.renderSize
     }
 
     private var showUserInputLabels: Bool {

--- a/Sources/AccessibilitySnapshot/Core/HitTargetSnapshotUtility.swift
+++ b/Sources/AccessibilitySnapshot/Core/HitTargetSnapshotUtility.swift
@@ -1,3 +1,4 @@
+import AccessibilitySnapshotParser
 import CoreImage
 import UIKit
 
@@ -61,7 +62,7 @@ public enum HitTargetSnapshotUtility {
             viewImage.draw(in: bounds)
 
             var viewToColorMap: [UIView: UIColor] = [:]
-            let pixelWidth: CGFloat = 1 / UIScreen.main.scale
+            let pixelWidth: CGFloat = 1 / view.effectiveDisplayScale
 
             let maxPermissibleMissedRegionWidth = max(pixelWidth, floor(maxPermissibleMissedRegionWidth))
             let maxPermissibleMissedRegionHeight = max(pixelWidth, floor(maxPermissibleMissedRegionHeight))

--- a/Sources/AccessibilitySnapshot/Core/HitTargetSnapshotView.swift
+++ b/Sources/AccessibilitySnapshot/Core/HitTargetSnapshotView.swift
@@ -14,7 +14,7 @@ public final class HitTargetSnapshotView: SnapshotAndLegendView {
         // Some implementations of hit testing rely on the window, so install the view in a window if needed.
         let requiresWindow = (baseView.window == nil && !(baseView is UIWindow))
         if requiresWindow {
-            let window = UIApplication.shared.firstKeyWindow ?? UIWindow(frame: UIScreen.main.bounds)
+            let window = UIApplication.shared.firstKeyWindow ?? UIWindow(frame: SnapshotPlatformDefaults.hostWindowFrame)
             window.addSubview(baseView)
         }
 

--- a/Sources/AccessibilitySnapshot/Core/SnapshotAndLegendView.swift
+++ b/Sources/AccessibilitySnapshot/Core/SnapshotAndLegendView.swift
@@ -1,3 +1,4 @@
+import AccessibilitySnapshotParser
 import UIKit
 
 open class SnapshotAndLegendView: UIView {
@@ -196,12 +197,12 @@ open class SnapshotAndLegendView: UIView {
 
 private extension CGFloat {
     func floorToPixel(in source: UIWindow?) -> CGFloat {
-        let scale = source?.screen.scale ?? 1
+        let scale = source?.effectiveDisplayScale ?? 1
         return floor(self * scale) / scale
     }
 
     func ceilToPixel(in source: UIWindow?) -> CGFloat {
-        let scale = source?.screen.scale ?? 1
+        let scale = source?.effectiveDisplayScale ?? 1
         return ceil(self * scale) / scale
     }
 }

--- a/Sources/AccessibilitySnapshot/Core/SnapshotPlatformDefaults.swift
+++ b/Sources/AccessibilitySnapshot/Core/SnapshotPlatformDefaults.swift
@@ -1,0 +1,22 @@
+import UIKit
+
+/// Platform-specific defaults used when no explicit size is provided for a snapshot.
+///
+/// On iOS these fall back to the main screen's bounds. `UIScreen` is unavailable on visionOS, where windows aren't
+/// backed by a screen at all, so an explicit default window size is used there instead.
+public enum SnapshotPlatformDefaults {
+    /// The frame to use for a host window when there is no existing key window to install a view in.
+    public static var hostWindowFrame: CGRect {
+        #if os(visionOS)
+        // The default size visionOS gives a plain window, in points.
+        return CGRect(origin: .zero, size: CGSize(width: 1280, height: 720))
+        #else
+        return UIScreen.main.bounds
+        #endif
+    }
+
+    /// The size to use when rendering a view for which no explicit render size was specified.
+    public static var renderSize: CGSize {
+        return hostWindowFrame.size
+    }
+}

--- a/Sources/AccessibilitySnapshot/Core/SnapshotPlatformDefaults.swift
+++ b/Sources/AccessibilitySnapshot/Core/SnapshotPlatformDefaults.swift
@@ -8,10 +8,10 @@ public enum SnapshotPlatformDefaults {
     /// The frame to use for a host window when there is no existing key window to install a view in.
     public static var hostWindowFrame: CGRect {
         #if os(visionOS)
-        // The default size visionOS gives a plain window, in points.
-        return CGRect(origin: .zero, size: CGSize(width: 1280, height: 720))
+            // The default size visionOS gives a plain window, in points.
+            return CGRect(origin: .zero, size: CGSize(width: 1280, height: 720))
         #else
-        return UIScreen.main.bounds
+            return UIScreen.main.bounds
         #endif
     }
 

--- a/Sources/AccessibilitySnapshot/Parser/Swift/Classes/AccessibilityHierarchyParser.swift
+++ b/Sources/AccessibilitySnapshot/Parser/Swift/Classes/AccessibilityHierarchyParser.swift
@@ -266,7 +266,7 @@ public final class AccessibilityHierarchyParser {
             usesDefaultActivationPoint: Self.usesDefaultActivationPoint(
                 element: object,
                 activationPoint: activationPoint,
-                screenScale: (root.window?.screen ?? UIScreen.main).scale
+                screenScale: root.effectiveDisplayScale
             ),
             customActions: object.accessibilityCustomActions?.map(\.name) ?? [],
             customContent: object.customContent,
@@ -1018,13 +1018,13 @@ private extension NSObject {
             if let provider = self as? AXCustomContentProvider {
                 // Swift 5.9 ships with Xcode 15 and the iOS 17 SDK.
                 #if swift(>=5.9)
-                    if #available(iOS 17.0, *) {
-                        if let customContentBlock = provider.accessibilityCustomContentBlock {
-                            if let content = customContentBlock?() {
-                                return content.map { .init(from: $0) }
-                            }
+                if #available(iOS 17.0, *) {
+                    if let customContentBlock = provider.accessibilityCustomContentBlock {
+                        if let content = customContentBlock?() {
+                            return content.map { .init(from: $0) }
                         }
                     }
+                }
                 #endif // swift(>=5.9)
                 if let content = provider.accessibilityCustomContent {
                     return content.map { .init(from: $0) }

--- a/Sources/AccessibilitySnapshot/Parser/Swift/Classes/AccessibilityHierarchyParser.swift
+++ b/Sources/AccessibilitySnapshot/Parser/Swift/Classes/AccessibilityHierarchyParser.swift
@@ -1018,13 +1018,13 @@ private extension NSObject {
             if let provider = self as? AXCustomContentProvider {
                 // Swift 5.9 ships with Xcode 15 and the iOS 17 SDK.
                 #if swift(>=5.9)
-                if #available(iOS 17.0, *) {
-                    if let customContentBlock = provider.accessibilityCustomContentBlock {
-                        if let content = customContentBlock?() {
-                            return content.map { .init(from: $0) }
+                    if #available(iOS 17.0, *) {
+                        if let customContentBlock = provider.accessibilityCustomContentBlock {
+                            if let content = customContentBlock?() {
+                                return content.map { .init(from: $0) }
+                            }
                         }
                     }
-                }
                 #endif // swift(>=5.9)
                 if let content = provider.accessibilityCustomContent {
                     return content.map { .init(from: $0) }

--- a/Sources/AccessibilitySnapshot/Parser/Swift/Classes/UIView+DisplayScale.swift
+++ b/Sources/AccessibilitySnapshot/Parser/Swift/Classes/UIView+DisplayScale.swift
@@ -1,0 +1,13 @@
+import UIKit
+
+public extension UIView {
+    /// The scale factor of the display the view is rendered on.
+    ///
+    /// This reads the scale from the view's trait environment rather than from `UIScreen`, which is unavailable on
+    /// visionOS. Views that aren't installed in a window may report a display scale of `0`, in which case this falls
+    /// back to an unscaled (`1`) value.
+    var effectiveDisplayScale: CGFloat {
+        let displayScale = traitCollection.displayScale
+        return displayScale > 0 ? displayScale : 1
+    }
+}

--- a/Sources/AccessibilitySnapshot/SnapshotTesting/SnapshotTesting+Accessibility.swift
+++ b/Sources/AccessibilitySnapshot/SnapshotTesting/SnapshotTesting+Accessibility.swift
@@ -3,390 +3,390 @@
 // available on visionOS and can be used directly there.
 #if os(iOS) || os(tvOS)
 
-import AccessibilitySnapshotCore
-import AccessibilitySnapshotParser
-import AccessibilitySnapshotParser_ObjC
-import AccessibilitySnapshotPreviews
-import SnapshotTesting
-import UIKit
+    import AccessibilitySnapshotCore
+    import AccessibilitySnapshotParser
+    import AccessibilitySnapshotParser_ObjC
+    import AccessibilitySnapshotPreviews
+    import SnapshotTesting
+    import UIKit
 
-public extension Snapshotting where Value == UIView, Format == UIImage {
-    /// Snapshots the current view with colored overlays of each accessibility element it contains, as well as an
-    /// approximation of the description that VoiceOver will read for each element.
-    static var accessibilityImage: Snapshotting {
-        return .accessibilityImage()
-    }
-
-    /// Snapshots the current view with colored overlays of each accessibility element it contains, as well as an
-    /// approximation of the description that VoiceOver will read for each element.
-    ///
-    /// - parameter showActivationPoints: When to show indicators for elements' accessibility activation points.
-    /// Defaults to showing activation points only when they are different than the default activation point for that
-    /// element.
-    /// - parameter useMonochromeSnapshot: Whether or not the snapshot of the `view` should be monochrome. Using a
-    /// monochrome snapshot makes it more clear where the highlighted elements are, but may make it difficult to
-    /// read certain views. Defaults to `true`.
-    /// - parameter drawHierarchyInKeyWindow: Whether or not to draw the view hierachy in the key window, rather than
-    /// rendering the view's layer. This enables the rendering of `UIAppearance` and `UIVisualEffect`s.
-    /// - parameter markerColors: The array of colors which will be chosen from when creating the overlays.
-    /// - parameter showUserInputLabels: Controls when to show elements' accessibility user input labels (used by Voice
-    /// Control).
-    /// - parameter shouldRunInHostApplication: Controls whether a host application is required to run the test or not.
-    /// - parameter precision: The percentage of pixels that must match. A value of `1` means all pixels must match,
-    /// while a value of `0.95` means that 95% of pixels must match.
-    /// - parameter perceptualPrecision: The percentage a pixel must match the source pixel to be considered a match.
-    /// `1` means the pixel must match exactly, while `0.98` means the pixel must be within 2% of the source pixel.
-    /// - parameter layoutEngine: The layout engine to use for rendering the accessibility overlays and legend.
-    /// Defaults to `LayoutEngine.default`.
-    static func accessibilityImage(
-        showActivationPoints activationPointDisplayMode: AccessibilityContentDisplayMode = .whenOverridden,
-        useMonochromeSnapshot: Bool = true,
-        drawHierarchyInKeyWindow: Bool = false,
-        markerColors: [UIColor] = [],
-        showUserInputLabels: Bool = true,
-        shouldRunInHostApplication: Bool = true,
-        precision: Float = 1,
-        perceptualPrecision: Float = 1,
-        layoutEngine: LayoutEngine = .default
-    ) -> Snapshotting {
-        guard !shouldRunInHostApplication || isRunningInHostApplication else {
-            fatalError("Accessibility snapshot tests cannot be run in a test target without a host application")
+    public extension Snapshotting where Value == UIView, Format == UIImage {
+        /// Snapshots the current view with colored overlays of each accessibility element it contains, as well as an
+        /// approximation of the description that VoiceOver will read for each element.
+        static var accessibilityImage: Snapshotting {
+            return .accessibilityImage()
         }
 
-        return Snapshotting<UIView, UIImage>
-            .image(drawHierarchyInKeyWindow: drawHierarchyInKeyWindow, precision: precision, perceptualPrecision: perceptualPrecision)
-            .pullback { view in
-
-                let configuration = AccessibilitySnapshotConfiguration(
-                    viewRenderingMode: drawHierarchyInKeyWindow ? .drawHierarchyInRect : .renderLayerInContext,
-                    colorRenderingMode: useMonochromeSnapshot ? .monochrome : .fullColor,
-                    overlayColors: markerColors,
-                    activationPointDisplay: activationPointDisplayMode,
-                    includesInputLabels: showUserInputLabels ? .whenOverridden : .never
-                )
-
-                let containerView: AccessibilitySnapshotBaseView
-
-                switch layoutEngine {
-                case .uikit:
-                    containerView = AccessibilitySnapshotView(
-                        containedView: view,
-                        snapshotConfiguration: configuration
-                    )
-
-                case .swiftui:
-                    guard #available(iOS 16.0, *) else {
-                        fatalError("SwiftUI layout engine requires iOS 16.0 or later")
-                    }
-                    containerView = SwiftUIAccessibilitySnapshotContainerView(
-                        containedView: view,
-                        snapshotConfiguration: configuration
-                    )
-                }
-
-                let window = UIWindow(frame: SnapshotPlatformDefaults.hostWindowFrame)
-                window.makeKeyAndVisible()
-                containerView.center = window.center
-                window.addSubview(containerView)
-
-                do {
-                    try containerView.parseAccessibility()
-                } catch ImageRenderingError.containedViewExceedsMaximumSize {
-                    fatalError(
-                        """
-                        View is too large to render monochrome snapshot. Try setting useMonochromeSnapshot to false or \
-                        use a different iOS version. In particular, this is known to fail on iOS 13, but was fixed in \
-                        iOS 14.
-                        """
-                    )
-                } catch ImageRenderingError.containedViewHasUnsupportedTransform {
-                    fatalError(
-                        """
-                        View has an unsupported transform for the specified snapshot parameters. Try using an identity \
-                        transform or changing the view rendering mode to render the layer in the graphics context.
-                        """
-                    )
-                } catch {
-                    fatalError("Failed to render snapshot image")
-                }
-
-                containerView.sizeToFit()
-
-                return containerView
-            }
-    }
-
-    /// Snapshots the current view simulating the way it will appear with Smart Invert Colors enabled.
-    static var imageWithSmartInvert: Snapshotting {
-        return .imageWithSmartInvert()
-    }
-
-    /// Snapshots the current view simulating the way it will appear with Smart Invert Colors enabled.
-    ///
-    /// - parameter precision: The percentage of pixels that must match. A value of `1` means all pixels must match,
-    /// while a value of `0.95` means that 95% of pixels must match.
-    /// - parameter perceptualPrecision: The percentage a pixel must match the source pixel to be considered a match.
-    /// `1` means the pixel must match exactly, while `0.98` means the pixel must be within 2% of the source pixel.
-    static func imageWithSmartInvert(
-        precision: Float = 1,
-        perceptualPrecision: Float = 1
-    ) -> Snapshotting {
-        func postNotification() {
-            NotificationCenter.default.post(
-                name: UIAccessibility.invertColorsStatusDidChangeNotification,
-                object: nil,
-                userInfo: nil
-            )
-        }
-
-        return Snapshotting<UIImage, UIImage>.image(precision: precision, perceptualPrecision: perceptualPrecision).pullback { view in
-            let requiresWindow = (view.window == nil && !(view is UIWindow))
-
-            if requiresWindow {
-                let window = UIApplication.shared.firstKeyWindow ?? UIWindow(frame: SnapshotPlatformDefaults.hostWindowFrame)
-                window.addSubview(view)
+        /// Snapshots the current view with colored overlays of each accessibility element it contains, as well as an
+        /// approximation of the description that VoiceOver will read for each element.
+        ///
+        /// - parameter showActivationPoints: When to show indicators for elements' accessibility activation points.
+        /// Defaults to showing activation points only when they are different than the default activation point for that
+        /// element.
+        /// - parameter useMonochromeSnapshot: Whether or not the snapshot of the `view` should be monochrome. Using a
+        /// monochrome snapshot makes it more clear where the highlighted elements are, but may make it difficult to
+        /// read certain views. Defaults to `true`.
+        /// - parameter drawHierarchyInKeyWindow: Whether or not to draw the view hierachy in the key window, rather than
+        /// rendering the view's layer. This enables the rendering of `UIAppearance` and `UIVisualEffect`s.
+        /// - parameter markerColors: The array of colors which will be chosen from when creating the overlays.
+        /// - parameter showUserInputLabels: Controls when to show elements' accessibility user input labels (used by Voice
+        /// Control).
+        /// - parameter shouldRunInHostApplication: Controls whether a host application is required to run the test or not.
+        /// - parameter precision: The percentage of pixels that must match. A value of `1` means all pixels must match,
+        /// while a value of `0.95` means that 95% of pixels must match.
+        /// - parameter perceptualPrecision: The percentage a pixel must match the source pixel to be considered a match.
+        /// `1` means the pixel must match exactly, while `0.98` means the pixel must be within 2% of the source pixel.
+        /// - parameter layoutEngine: The layout engine to use for rendering the accessibility overlays and legend.
+        /// Defaults to `LayoutEngine.default`.
+        static func accessibilityImage(
+            showActivationPoints activationPointDisplayMode: AccessibilityContentDisplayMode = .whenOverridden,
+            useMonochromeSnapshot: Bool = true,
+            drawHierarchyInKeyWindow: Bool = false,
+            markerColors: [UIColor] = [],
+            showUserInputLabels: Bool = true,
+            shouldRunInHostApplication: Bool = true,
+            precision: Float = 1,
+            perceptualPrecision: Float = 1,
+            layoutEngine: LayoutEngine = .default
+        ) -> Snapshotting {
+            guard !shouldRunInHostApplication || isRunningInHostApplication else {
+                fatalError("Accessibility snapshot tests cannot be run in a test target without a host application")
             }
 
-            view.layoutIfNeeded()
+            return Snapshotting<UIView, UIImage>
+                .image(drawHierarchyInKeyWindow: drawHierarchyInKeyWindow, precision: precision, perceptualPrecision: perceptualPrecision)
+                .pullback { view in
 
-            let statusUtility = UIAccessibilityStatusUtility()
-            statusUtility.mockInvertColorsStatus()
-            postNotification()
-
-            let renderer = UIGraphicsImageRenderer(bounds: view.bounds)
-            let image = renderer.image { context in
-                view.drawHierarchyWithInvertedColors(in: view.bounds, using: context)
-            }
-
-            statusUtility.unmockStatuses()
-            postNotification()
-
-            if requiresWindow {
-                view.removeFromSuperview()
-            }
-
-            return image
-        }
-    }
-
-    /// Snapshots the view with hit target regions highlighted.
-    ///
-    /// The hit target regions are highlighted using the following rules:
-    ///
-    /// * Regions that hit test to the base view will not be highlighted.
-    /// * Regions that hit test to `nil` will be darkened.
-    /// * Regions that hit test to another view will be highlighted using one of the specified `colors`.
-    ///
-    /// By default this snapshot is very slow (on the order of 50 seconds for a full screen snapshot) since it hit tests
-    /// every pixel in the view to achieve a perfectly accurate result. As a performance optimization, you can trade off
-    /// greatly increased performance for the possibility of missing very thin views by defining the maximum width and
-    /// height of a region you are okay with missing (`maxPermissibleMissedRegion{Width,Height}`). In particular, this
-    /// might miss hit regions of the specified width/height or less **which have the same hit target both above and
-    /// below the region**. Note these are independent controls - a region could be missed if it falls beneath either of
-    /// these thresholds, not both. Setting the either value alone to 1 pt improves the run time by almost (1 / scale
-    /// factor), i.e. a 65% improvement for a 3x scale device, and setting both to 1 pt improves the run time by an
-    /// additional (1 / scale factor), i.e. an ~88% improvement for a 3x scale device, so this trade-off is often worth
-    /// it. Increasing the value from there will continue to decrease the run time, but you quickly get diminishing
-    /// returns, so you likely won't ever want to go above 2-4 pt and should stick to 0 or 1 pt unless you have a large
-    /// number of snapshots.
-    ///
-    /// - parameter useMonochromeSnapshot: Whether or not the snapshot of the view should be monochrome. Using a
-    /// monochrome snapshot makes it more clear where the highlighted elements are, but may make it difficult to
-    /// read certain views.
-    /// - parameter drawHierarchyInKeyWindow: Whether or not to draw the view hierachy in the key window, rather than
-    /// rendering the view's layer. This enables the rendering of `UIAppearance` and `UIVisualEffect`s.
-    /// - parameter colors: An array of colors to use for the highlighted regions. These colors will be used in order,
-    /// repeating through the array as necessary and avoiding adjacent regions using the same color when possible.
-    /// - parameter maxPermissibleMissedRegionWidth: The maximum width for which it is permissible to "miss" a view.
-    /// Value must be a positive integer.
-    /// - parameter maxPermissibleMissedRegionHeight: The maximum height for which it is permissible to "miss" a view.
-    /// Value must be a positive integer.
-    /// - parameter file: The file in which errors should be attributed.
-    /// - parameter line: The line in which errors should be attributed.
-    /// - parameter precision: The percentage of pixels that must match. A value of `1` means all pixels must match,
-    /// while a value of `0.95` means that 95% of pixels must match.
-    /// - parameter perceptualPrecision: The percentage a pixel must match the source pixel to be considered a match.
-    /// `1` means the pixel must match exactly, while `0.98` means the pixel must be within 2% of the source pixel.
-    static func imageWithHitTargets(
-        useMonochromeSnapshot: Bool = true,
-        drawHierarchyInKeyWindow: Bool = false,
-        colors: [UIColor] = [],
-        maxPermissibleMissedRegionWidth: CGFloat = 0,
-        maxPermissibleMissedRegionHeight: CGFloat = 0,
-        precision: Float = 1,
-        perceptualPrecision: Float = 1,
-        file: StaticString = #file,
-        line: UInt = #line
-    ) -> Snapshotting {
-        return Snapshotting<UIView, UIImage>
-            .image(drawHierarchyInKeyWindow: drawHierarchyInKeyWindow, precision: precision, perceptualPrecision: perceptualPrecision)
-            .pullback { view in
-                do {
-                    return try HitTargetSnapshotView(
-                        baseView: view,
-                        useMonochromeSnapshot: useMonochromeSnapshot,
+                    let configuration = AccessibilitySnapshotConfiguration(
                         viewRenderingMode: drawHierarchyInKeyWindow ? .drawHierarchyInRect : .renderLayerInContext,
-                        colors: colors,
-                        maxPermissibleMissedRegionWidth: maxPermissibleMissedRegionWidth,
-                        maxPermissibleMissedRegionHeight: maxPermissibleMissedRegionHeight
+                        colorRenderingMode: useMonochromeSnapshot ? .monochrome : .fullColor,
+                        overlayColors: markerColors,
+                        activationPointDisplay: activationPointDisplayMode,
+                        includesInputLabels: showUserInputLabels ? .whenOverridden : .never
                     )
-                } catch ImageRenderingError.containedViewExceedsMaximumSize {
-                    fatalError(
-                        """
-                        View is too large to render monochrome snapshot. Try setting useMonochromeSnapshot to false or \
-                        use a different iOS version. In particular, this is known to fail on iOS 13, but was fixed in \
-                        iOS 14.
-                        """,
-                        file: file,
-                        line: line
-                    )
-                } catch ImageRenderingError.containedViewHasUnsupportedTransform {
-                    fatalError(
-                        """
-                        View has an unsupported transform for the specified snapshot parameters. Try using an identity \
-                        transform or changing the view rendering mode to render the layer in the graphics context.
-                        """,
-                        file: file,
-                        line: line
-                    )
-                } catch {
-                    fatalError("Failed to render snapshot image", file: file, line: line)
+
+                    let containerView: AccessibilitySnapshotBaseView
+
+                    switch layoutEngine {
+                    case .uikit:
+                        containerView = AccessibilitySnapshotView(
+                            containedView: view,
+                            snapshotConfiguration: configuration
+                        )
+
+                    case .swiftui:
+                        guard #available(iOS 16.0, *) else {
+                            fatalError("SwiftUI layout engine requires iOS 16.0 or later")
+                        }
+                        containerView = SwiftUIAccessibilitySnapshotContainerView(
+                            containedView: view,
+                            snapshotConfiguration: configuration
+                        )
+                    }
+
+                    let window = UIWindow(frame: SnapshotPlatformDefaults.hostWindowFrame)
+                    window.makeKeyAndVisible()
+                    containerView.center = window.center
+                    window.addSubview(containerView)
+
+                    do {
+                        try containerView.parseAccessibility()
+                    } catch ImageRenderingError.containedViewExceedsMaximumSize {
+                        fatalError(
+                            """
+                            View is too large to render monochrome snapshot. Try setting useMonochromeSnapshot to false or \
+                            use a different iOS version. In particular, this is known to fail on iOS 13, but was fixed in \
+                            iOS 14.
+                            """
+                        )
+                    } catch ImageRenderingError.containedViewHasUnsupportedTransform {
+                        fatalError(
+                            """
+                            View has an unsupported transform for the specified snapshot parameters. Try using an identity \
+                            transform or changing the view rendering mode to render the layer in the graphics context.
+                            """
+                        )
+                    } catch {
+                        fatalError("Failed to render snapshot image")
+                    }
+
+                    containerView.sizeToFit()
+
+                    return containerView
                 }
+        }
+
+        /// Snapshots the current view simulating the way it will appear with Smart Invert Colors enabled.
+        static var imageWithSmartInvert: Snapshotting {
+            return .imageWithSmartInvert()
+        }
+
+        /// Snapshots the current view simulating the way it will appear with Smart Invert Colors enabled.
+        ///
+        /// - parameter precision: The percentage of pixels that must match. A value of `1` means all pixels must match,
+        /// while a value of `0.95` means that 95% of pixels must match.
+        /// - parameter perceptualPrecision: The percentage a pixel must match the source pixel to be considered a match.
+        /// `1` means the pixel must match exactly, while `0.98` means the pixel must be within 2% of the source pixel.
+        static func imageWithSmartInvert(
+            precision: Float = 1,
+            perceptualPrecision: Float = 1
+        ) -> Snapshotting {
+            func postNotification() {
+                NotificationCenter.default.post(
+                    name: UIAccessibility.invertColorsStatusDidChangeNotification,
+                    object: nil,
+                    userInfo: nil
+                )
             }
-    }
 
-    // MARK: - Internal Properties
+            return Snapshotting<UIImage, UIImage>.image(precision: precision, perceptualPrecision: perceptualPrecision).pullback { view in
+                let requiresWindow = (view.window == nil && !(view is UIWindow))
 
-    internal static var isRunningInHostApplication: Bool {
-        // The tests must be run in a host application in order for the accessibility properties to be populated
-        // correctly. The `UIApplication.shared` singleton is non-optional, but will be uninitialized when the tests are
-        // running outside of a host application, so we can use this check to determine whether we have a test host.
-        let hostApplication: UIApplication? = UIApplication.shared
-        return hostApplication != nil
-    }
-}
+                if requiresWindow {
+                    let window = UIApplication.shared.firstKeyWindow ?? UIWindow(frame: SnapshotPlatformDefaults.hostWindowFrame)
+                    window.addSubview(view)
+                }
 
-public extension Snapshotting where Value == UIViewController, Format == UIImage {
-    /// Snapshots the current view with colored overlays of each accessibility element it contains, as well as an
-    /// approximation of the description that VoiceOver will read for each element.
-    static var accessibilityImage: Snapshotting {
-        return .accessibilityImage()
-    }
+                view.layoutIfNeeded()
 
-    /// Snapshots the current view with colored overlays of each accessibility element it contains, as well as an
-    /// approximation of the description that VoiceOver will read for each element.
-    ///
-    /// - parameter showActivationPoints: When to show indicators for elements' accessibility activation points.
-    /// Defaults to showing activation points only when they are different than the default activation point for that
-    /// element.
-    /// - parameter useMonochromeSnapshot: Whether or not the snapshot of the `view` should be monochrome. Using a
-    /// monochrome snapshot makes it more clear where the highlighted elements are, but may make it difficult to
-    /// read certain views. Defaults to `true`.
-    /// - parameter drawHierarchyInKeyWindow: Whether or not to draw the view hierachy in the key window, rather than
-    /// rendering the view's layer. This enables the rendering of `UIAppearance` and `UIVisualEffect`s.
-    /// - parameter markerColors: The array of colors which will be chosen from when creating the overlays.
-    /// - parameter showUserInputLabels: Controls when to show elements' accessibility user input labels (used by Voice
-    /// Control).
-    /// - parameter precision: The percentage of pixels that must match. A value of `1` means all pixels must match,
-    /// while a value of `0.95` means that 95% of pixels must match.
-    /// - parameter perceptualPrecision: The percentage a pixel must match the source pixel to be considered a match.
-    /// `1` means the pixel must match exactly, while `0.98` means the pixel must be within 2% of the source pixel.
-    /// - parameter layoutEngine: The layout engine to use for rendering the accessibility overlays and legend.
-    /// Defaults to `LayoutEngine.default`.
-    static func accessibilityImage(
-        showActivationPoints activationPointDisplayMode: AccessibilityContentDisplayMode = .whenOverridden,
-        useMonochromeSnapshot: Bool = true,
-        drawHierarchyInKeyWindow: Bool = false,
-        markerColors: [UIColor] = [],
-        showUserInputLabels: Bool = true,
-        shouldRunInHostApplication: Bool = true,
-        precision: Float = 1,
-        perceptualPrecision: Float = 1,
-        layoutEngine: LayoutEngine = .default
-    ) -> Snapshotting {
-        return Snapshotting<UIView, UIImage>
-            .accessibilityImage(
-                showActivationPoints: activationPointDisplayMode,
-                useMonochromeSnapshot: useMonochromeSnapshot,
-                drawHierarchyInKeyWindow: drawHierarchyInKeyWindow,
-                markerColors: markerColors,
-                showUserInputLabels: showUserInputLabels,
-                shouldRunInHostApplication: shouldRunInHostApplication,
-                precision: precision,
-                perceptualPrecision: perceptualPrecision,
-                layoutEngine: layoutEngine
-            )
-            .pullback { viewController in
-                viewController.view
+                let statusUtility = UIAccessibilityStatusUtility()
+                statusUtility.mockInvertColorsStatus()
+                postNotification()
+
+                let renderer = UIGraphicsImageRenderer(bounds: view.bounds)
+                let image = renderer.image { context in
+                    view.drawHierarchyWithInvertedColors(in: view.bounds, using: context)
+                }
+
+                statusUtility.unmockStatuses()
+                postNotification()
+
+                if requiresWindow {
+                    view.removeFromSuperview()
+                }
+
+                return image
             }
+        }
+
+        /// Snapshots the view with hit target regions highlighted.
+        ///
+        /// The hit target regions are highlighted using the following rules:
+        ///
+        /// * Regions that hit test to the base view will not be highlighted.
+        /// * Regions that hit test to `nil` will be darkened.
+        /// * Regions that hit test to another view will be highlighted using one of the specified `colors`.
+        ///
+        /// By default this snapshot is very slow (on the order of 50 seconds for a full screen snapshot) since it hit tests
+        /// every pixel in the view to achieve a perfectly accurate result. As a performance optimization, you can trade off
+        /// greatly increased performance for the possibility of missing very thin views by defining the maximum width and
+        /// height of a region you are okay with missing (`maxPermissibleMissedRegion{Width,Height}`). In particular, this
+        /// might miss hit regions of the specified width/height or less **which have the same hit target both above and
+        /// below the region**. Note these are independent controls - a region could be missed if it falls beneath either of
+        /// these thresholds, not both. Setting the either value alone to 1 pt improves the run time by almost (1 / scale
+        /// factor), i.e. a 65% improvement for a 3x scale device, and setting both to 1 pt improves the run time by an
+        /// additional (1 / scale factor), i.e. an ~88% improvement for a 3x scale device, so this trade-off is often worth
+        /// it. Increasing the value from there will continue to decrease the run time, but you quickly get diminishing
+        /// returns, so you likely won't ever want to go above 2-4 pt and should stick to 0 or 1 pt unless you have a large
+        /// number of snapshots.
+        ///
+        /// - parameter useMonochromeSnapshot: Whether or not the snapshot of the view should be monochrome. Using a
+        /// monochrome snapshot makes it more clear where the highlighted elements are, but may make it difficult to
+        /// read certain views.
+        /// - parameter drawHierarchyInKeyWindow: Whether or not to draw the view hierachy in the key window, rather than
+        /// rendering the view's layer. This enables the rendering of `UIAppearance` and `UIVisualEffect`s.
+        /// - parameter colors: An array of colors to use for the highlighted regions. These colors will be used in order,
+        /// repeating through the array as necessary and avoiding adjacent regions using the same color when possible.
+        /// - parameter maxPermissibleMissedRegionWidth: The maximum width for which it is permissible to "miss" a view.
+        /// Value must be a positive integer.
+        /// - parameter maxPermissibleMissedRegionHeight: The maximum height for which it is permissible to "miss" a view.
+        /// Value must be a positive integer.
+        /// - parameter file: The file in which errors should be attributed.
+        /// - parameter line: The line in which errors should be attributed.
+        /// - parameter precision: The percentage of pixels that must match. A value of `1` means all pixels must match,
+        /// while a value of `0.95` means that 95% of pixels must match.
+        /// - parameter perceptualPrecision: The percentage a pixel must match the source pixel to be considered a match.
+        /// `1` means the pixel must match exactly, while `0.98` means the pixel must be within 2% of the source pixel.
+        static func imageWithHitTargets(
+            useMonochromeSnapshot: Bool = true,
+            drawHierarchyInKeyWindow: Bool = false,
+            colors: [UIColor] = [],
+            maxPermissibleMissedRegionWidth: CGFloat = 0,
+            maxPermissibleMissedRegionHeight: CGFloat = 0,
+            precision: Float = 1,
+            perceptualPrecision: Float = 1,
+            file: StaticString = #file,
+            line: UInt = #line
+        ) -> Snapshotting {
+            return Snapshotting<UIView, UIImage>
+                .image(drawHierarchyInKeyWindow: drawHierarchyInKeyWindow, precision: precision, perceptualPrecision: perceptualPrecision)
+                .pullback { view in
+                    do {
+                        return try HitTargetSnapshotView(
+                            baseView: view,
+                            useMonochromeSnapshot: useMonochromeSnapshot,
+                            viewRenderingMode: drawHierarchyInKeyWindow ? .drawHierarchyInRect : .renderLayerInContext,
+                            colors: colors,
+                            maxPermissibleMissedRegionWidth: maxPermissibleMissedRegionWidth,
+                            maxPermissibleMissedRegionHeight: maxPermissibleMissedRegionHeight
+                        )
+                    } catch ImageRenderingError.containedViewExceedsMaximumSize {
+                        fatalError(
+                            """
+                            View is too large to render monochrome snapshot. Try setting useMonochromeSnapshot to false or \
+                            use a different iOS version. In particular, this is known to fail on iOS 13, but was fixed in \
+                            iOS 14.
+                            """,
+                            file: file,
+                            line: line
+                        )
+                    } catch ImageRenderingError.containedViewHasUnsupportedTransform {
+                        fatalError(
+                            """
+                            View has an unsupported transform for the specified snapshot parameters. Try using an identity \
+                            transform or changing the view rendering mode to render the layer in the graphics context.
+                            """,
+                            file: file,
+                            line: line
+                        )
+                    } catch {
+                        fatalError("Failed to render snapshot image", file: file, line: line)
+                    }
+                }
+        }
+
+        // MARK: - Internal Properties
+
+        internal static var isRunningInHostApplication: Bool {
+            // The tests must be run in a host application in order for the accessibility properties to be populated
+            // correctly. The `UIApplication.shared` singleton is non-optional, but will be uninitialized when the tests are
+            // running outside of a host application, so we can use this check to determine whether we have a test host.
+            let hostApplication: UIApplication? = UIApplication.shared
+            return hostApplication != nil
+        }
     }
 
-    /// Snapshots the current view simulating the way it will appear with Smart Invert Colors enabled.
-    static var imageWithSmartInvert: Snapshotting {
-        return .imageWithSmartInvert()
-    }
+    public extension Snapshotting where Value == UIViewController, Format == UIImage {
+        /// Snapshots the current view with colored overlays of each accessibility element it contains, as well as an
+        /// approximation of the description that VoiceOver will read for each element.
+        static var accessibilityImage: Snapshotting {
+            return .accessibilityImage()
+        }
 
-    /// Snapshots the current view simulating the way it will appear with Smart Invert Colors enabled.
-    ///
-    /// - parameter precision: The percentage of pixels that must match. A value of `1` means all pixels must match,
-    /// while a value of `0.95` means that 95% of pixels must match.
-    /// - parameter perceptualPrecision: The percentage a pixel must match the source pixel to be considered a match.
-    /// `1` means the pixel must match exactly, while `0.98` means the pixel must be within 2% of the source pixel.
-    static func imageWithSmartInvert(
-        precision: Float = 1,
-        perceptualPrecision: Float = 1
-    ) -> Snapshotting {
-        return Snapshotting<UIView, UIImage>
-            .imageWithSmartInvert(precision: precision, perceptualPrecision: perceptualPrecision)
-            .pullback { viewController in
-                viewController.view
-            }
-    }
+        /// Snapshots the current view with colored overlays of each accessibility element it contains, as well as an
+        /// approximation of the description that VoiceOver will read for each element.
+        ///
+        /// - parameter showActivationPoints: When to show indicators for elements' accessibility activation points.
+        /// Defaults to showing activation points only when they are different than the default activation point for that
+        /// element.
+        /// - parameter useMonochromeSnapshot: Whether or not the snapshot of the `view` should be monochrome. Using a
+        /// monochrome snapshot makes it more clear where the highlighted elements are, but may make it difficult to
+        /// read certain views. Defaults to `true`.
+        /// - parameter drawHierarchyInKeyWindow: Whether or not to draw the view hierachy in the key window, rather than
+        /// rendering the view's layer. This enables the rendering of `UIAppearance` and `UIVisualEffect`s.
+        /// - parameter markerColors: The array of colors which will be chosen from when creating the overlays.
+        /// - parameter showUserInputLabels: Controls when to show elements' accessibility user input labels (used by Voice
+        /// Control).
+        /// - parameter precision: The percentage of pixels that must match. A value of `1` means all pixels must match,
+        /// while a value of `0.95` means that 95% of pixels must match.
+        /// - parameter perceptualPrecision: The percentage a pixel must match the source pixel to be considered a match.
+        /// `1` means the pixel must match exactly, while `0.98` means the pixel must be within 2% of the source pixel.
+        /// - parameter layoutEngine: The layout engine to use for rendering the accessibility overlays and legend.
+        /// Defaults to `LayoutEngine.default`.
+        static func accessibilityImage(
+            showActivationPoints activationPointDisplayMode: AccessibilityContentDisplayMode = .whenOverridden,
+            useMonochromeSnapshot: Bool = true,
+            drawHierarchyInKeyWindow: Bool = false,
+            markerColors: [UIColor] = [],
+            showUserInputLabels: Bool = true,
+            shouldRunInHostApplication: Bool = true,
+            precision: Float = 1,
+            perceptualPrecision: Float = 1,
+            layoutEngine: LayoutEngine = .default
+        ) -> Snapshotting {
+            return Snapshotting<UIView, UIImage>
+                .accessibilityImage(
+                    showActivationPoints: activationPointDisplayMode,
+                    useMonochromeSnapshot: useMonochromeSnapshot,
+                    drawHierarchyInKeyWindow: drawHierarchyInKeyWindow,
+                    markerColors: markerColors,
+                    showUserInputLabels: showUserInputLabels,
+                    shouldRunInHostApplication: shouldRunInHostApplication,
+                    precision: precision,
+                    perceptualPrecision: perceptualPrecision,
+                    layoutEngine: layoutEngine
+                )
+                .pullback { viewController in
+                    viewController.view
+                }
+        }
 
-    /// Snapshots the view controller with hit target regions highlighted.
-    ///
-    /// The hit target regions are highlighted using the following rules:
-    ///
-    /// * Regions that hit test to the base view (the view controller's `view`) will not be highlighted.
-    /// * Regions that hit test to `nil` will be darkened.
-    /// * Regions that hit test to another view will be highlighted using one of the specified `colors`.
-    ///
-    /// - parameter useMonochromeSnapshot: Whether or not the snapshot of the view should be monochrome. Using a
-    /// monochrome snapshot makes it more clear where the highlighted elements are, but may make it difficult to
-    /// read certain views.
-    /// - parameter drawHierarchyInKeyWindow: Whether or not to draw the view hierachy in the key window, rather than
-    /// rendering the view's layer. This enables the rendering of `UIAppearance` and `UIVisualEffect`s.
-    /// - parameter colors: An array of colors to use for the highlighted regions. These colors will be used in order,
-    /// repeating through the array as necessary and avoiding adjacent regions using the same color when possible.
-    /// - parameter file: The file in which errors should be attributed.
-    /// - parameter line: The line in which errors should be attributed.
-    /// - parameter precision: The percentage of pixels that must match. A value of `1` means all pixels must match,
-    /// while a value of `0.95` means that 95% of pixels must match.
-    /// - parameter perceptualPrecision: The percentage a pixel must match the source pixel to be considered a match.
-    /// `1` means the pixel must match exactly, while `0.98` means the pixel must be within 2% of the source pixel.
-    static func imageWithHitTargets(
-        useMonochromeSnapshot: Bool = true,
-        drawHierarchyInKeyWindow: Bool = false,
-        colors: [UIColor] = [],
-        precision: Float = 1,
-        perceptualPrecision: Float = 1,
-        file: StaticString = #file,
-        line: UInt = #line
-    ) -> Snapshotting {
-        return Snapshotting<UIView, UIImage>
-            .imageWithHitTargets(
-                useMonochromeSnapshot: useMonochromeSnapshot,
-                drawHierarchyInKeyWindow: drawHierarchyInKeyWindow,
-                colors: colors,
-                precision: precision,
-                perceptualPrecision: perceptualPrecision,
-                file: file,
-                line: line
-            )
-            .pullback { viewController in
-                viewController.view
-            }
+        /// Snapshots the current view simulating the way it will appear with Smart Invert Colors enabled.
+        static var imageWithSmartInvert: Snapshotting {
+            return .imageWithSmartInvert()
+        }
+
+        /// Snapshots the current view simulating the way it will appear with Smart Invert Colors enabled.
+        ///
+        /// - parameter precision: The percentage of pixels that must match. A value of `1` means all pixels must match,
+        /// while a value of `0.95` means that 95% of pixels must match.
+        /// - parameter perceptualPrecision: The percentage a pixel must match the source pixel to be considered a match.
+        /// `1` means the pixel must match exactly, while `0.98` means the pixel must be within 2% of the source pixel.
+        static func imageWithSmartInvert(
+            precision: Float = 1,
+            perceptualPrecision: Float = 1
+        ) -> Snapshotting {
+            return Snapshotting<UIView, UIImage>
+                .imageWithSmartInvert(precision: precision, perceptualPrecision: perceptualPrecision)
+                .pullback { viewController in
+                    viewController.view
+                }
+        }
+
+        /// Snapshots the view controller with hit target regions highlighted.
+        ///
+        /// The hit target regions are highlighted using the following rules:
+        ///
+        /// * Regions that hit test to the base view (the view controller's `view`) will not be highlighted.
+        /// * Regions that hit test to `nil` will be darkened.
+        /// * Regions that hit test to another view will be highlighted using one of the specified `colors`.
+        ///
+        /// - parameter useMonochromeSnapshot: Whether or not the snapshot of the view should be monochrome. Using a
+        /// monochrome snapshot makes it more clear where the highlighted elements are, but may make it difficult to
+        /// read certain views.
+        /// - parameter drawHierarchyInKeyWindow: Whether or not to draw the view hierachy in the key window, rather than
+        /// rendering the view's layer. This enables the rendering of `UIAppearance` and `UIVisualEffect`s.
+        /// - parameter colors: An array of colors to use for the highlighted regions. These colors will be used in order,
+        /// repeating through the array as necessary and avoiding adjacent regions using the same color when possible.
+        /// - parameter file: The file in which errors should be attributed.
+        /// - parameter line: The line in which errors should be attributed.
+        /// - parameter precision: The percentage of pixels that must match. A value of `1` means all pixels must match,
+        /// while a value of `0.95` means that 95% of pixels must match.
+        /// - parameter perceptualPrecision: The percentage a pixel must match the source pixel to be considered a match.
+        /// `1` means the pixel must match exactly, while `0.98` means the pixel must be within 2% of the source pixel.
+        static func imageWithHitTargets(
+            useMonochromeSnapshot: Bool = true,
+            drawHierarchyInKeyWindow: Bool = false,
+            colors: [UIColor] = [],
+            precision: Float = 1,
+            perceptualPrecision: Float = 1,
+            file: StaticString = #file,
+            line: UInt = #line
+        ) -> Snapshotting {
+            return Snapshotting<UIView, UIImage>
+                .imageWithHitTargets(
+                    useMonochromeSnapshot: useMonochromeSnapshot,
+                    drawHierarchyInKeyWindow: drawHierarchyInKeyWindow,
+                    colors: colors,
+                    precision: precision,
+                    perceptualPrecision: perceptualPrecision,
+                    file: file,
+                    line: line
+                )
+                .pullback { viewController in
+                    viewController.view
+                }
+        }
     }
-}
 
 #endif

--- a/Sources/AccessibilitySnapshot/SnapshotTesting/SnapshotTesting+Accessibility.swift
+++ b/Sources/AccessibilitySnapshot/SnapshotTesting/SnapshotTesting+Accessibility.swift
@@ -1,8 +1,13 @@
+// swift-snapshot-testing only vends its UIKit image strategies on iOS and tvOS, so the strategies built on top of them
+// are unavailable on visionOS. The parsing and rendering layers (AccessibilitySnapshotParser, -Core, -Previews) are
+// available on visionOS and can be used directly there.
+#if os(iOS) || os(tvOS)
+
 import AccessibilitySnapshotCore
 import AccessibilitySnapshotParser
 import AccessibilitySnapshotParser_ObjC
-import SnapshotTesting
 import AccessibilitySnapshotPreviews
+import SnapshotTesting
 import UIKit
 
 public extension Snapshotting where Value == UIView, Format == UIImage {
@@ -79,7 +84,7 @@ public extension Snapshotting where Value == UIView, Format == UIImage {
                     )
                 }
 
-                let window = UIWindow(frame: UIScreen.main.bounds)
+                let window = UIWindow(frame: SnapshotPlatformDefaults.hostWindowFrame)
                 window.makeKeyAndVisible()
                 containerView.center = window.center
                 window.addSubview(containerView)
@@ -138,7 +143,7 @@ public extension Snapshotting where Value == UIView, Format == UIImage {
             let requiresWindow = (view.window == nil && !(view is UIWindow))
 
             if requiresWindow {
-                let window = UIApplication.shared.firstKeyWindow ?? UIWindow(frame: UIScreen.main.bounds)
+                let window = UIApplication.shared.firstKeyWindow ?? UIWindow(frame: SnapshotPlatformDefaults.hostWindowFrame)
                 window.addSubview(view)
             }
 
@@ -383,3 +388,5 @@ public extension Snapshotting where Value == UIViewController, Format == UIImage
             }
     }
 }
+
+#endif

--- a/Sources/AccessibilitySnapshot/SnapshotTesting/SnapshotTesting+Keyboard.swift
+++ b/Sources/AccessibilitySnapshot/SnapshotTesting/SnapshotTesting+Keyboard.swift
@@ -1,243 +1,249 @@
-import AccessibilitySnapshotCore
-import SnapshotTesting
-import SwiftUI
-import UIKit
+// See the note in SnapshotTesting+Accessibility.swift: swift-snapshot-testing's UIKit image strategies are iOS/tvOS
+// only, so these strategies are as well.
+#if os(iOS) || os(tvOS)
 
-public extension Snapshotting where Value == UIView, Format == UIImage {
-    /// Creates a snapshot strategy that renders the view with a legend of keyboard accessibility information.
-    ///
-    /// This variant parses shortcuts from the view's responder chain, without category grouping.
-    ///
-    /// - parameter useMonochromeSnapshot: Whether or not the snapshot of the `view` should be monochrome. Using a
-    /// monochrome snapshot makes it more clear where the highlighted elements are, but may make it difficult to
-    /// read certain views. Defaults to `true`.
-    /// - parameter drawHierarchyInKeyWindow: Whether or not to draw the view hierachy in the key window, rather than
-    /// rendering the view's layer. This enables the rendering of `UIAppearance` and `UIVisualEffect`s.
-    /// - parameter precision: The percentage of pixels that must match. A value of `1` means all pixels must match,
-    /// while a value of `0.95` means that 95% of pixels must match.
-    /// - parameter perceptualPrecision: The percentage a pixel must match the source pixel to be considered a match.
-    /// `1` means the pixel must match exactly, while `0.98` means the pixel must be within 2% of the source pixel.
-    static func keyboardAccessibilityImage(
-        useMonochromeSnapshot: Bool = true,
-        drawHierarchyInKeyWindow: Bool = false,
-        precision: Float = 1,
-        perceptualPrecision: Float = 1
-    ) -> Snapshotting {
-        return Snapshotting<UIView, UIImage>.image(
-            drawHierarchyInKeyWindow: drawHierarchyInKeyWindow,
-            precision: precision,
-            perceptualPrecision: perceptualPrecision
-        ).pullback { view in
-            makeSnapshotContainer(
-                for: view,
-                menu: nil,
-                useMonochromeSnapshot: useMonochromeSnapshot,
-                renderingMode: drawHierarchyInKeyWindow ? .drawHierarchyInRect : .renderLayerInContext
-            )
+    import AccessibilitySnapshotCore
+    import SnapshotTesting
+    import SwiftUI
+    import UIKit
+
+    public extension Snapshotting where Value == UIView, Format == UIImage {
+        /// Creates a snapshot strategy that renders the view with a legend of keyboard accessibility information.
+        ///
+        /// This variant parses shortcuts from the view's responder chain, without category grouping.
+        ///
+        /// - parameter useMonochromeSnapshot: Whether or not the snapshot of the `view` should be monochrome. Using a
+        /// monochrome snapshot makes it more clear where the highlighted elements are, but may make it difficult to
+        /// read certain views. Defaults to `true`.
+        /// - parameter drawHierarchyInKeyWindow: Whether or not to draw the view hierachy in the key window, rather than
+        /// rendering the view's layer. This enables the rendering of `UIAppearance` and `UIVisualEffect`s.
+        /// - parameter precision: The percentage of pixels that must match. A value of `1` means all pixels must match,
+        /// while a value of `0.95` means that 95% of pixels must match.
+        /// - parameter perceptualPrecision: The percentage a pixel must match the source pixel to be considered a match.
+        /// `1` means the pixel must match exactly, while `0.98` means the pixel must be within 2% of the source pixel.
+        static func keyboardAccessibilityImage(
+            useMonochromeSnapshot: Bool = true,
+            drawHierarchyInKeyWindow: Bool = false,
+            precision: Float = 1,
+            perceptualPrecision: Float = 1
+        ) -> Snapshotting {
+            return Snapshotting<UIView, UIImage>.image(
+                drawHierarchyInKeyWindow: drawHierarchyInKeyWindow,
+                precision: precision,
+                perceptualPrecision: perceptualPrecision
+            ).pullback { view in
+                makeSnapshotContainer(
+                    for: view,
+                    menu: nil,
+                    useMonochromeSnapshot: useMonochromeSnapshot,
+                    renderingMode: drawHierarchyInKeyWindow ? .drawHierarchyInRect : .renderLayerInContext
+                )
+            }
+        }
+
+        /// Creates a snapshot strategy that renders the view with a legend of keyboard shortcuts from a UIMenu.
+        ///
+        /// This variant uses the provided UIMenu to extract shortcuts with category grouping based on submenu titles.
+        ///
+        /// - parameter menu: The UIMenu containing keyboard shortcuts organized by category.
+        /// - parameter useMonochromeSnapshot: Whether or not the snapshot of the `view` should be monochrome. Using a
+        /// monochrome snapshot makes it more clear where the highlighted elements are, but may make it difficult to
+        /// read certain views. Defaults to `true`.
+        /// - parameter drawHierarchyInKeyWindow: Whether or not to draw the view hierachy in the key window, rather than
+        /// rendering the view's layer. This enables the rendering of `UIAppearance` and `UIVisualEffect`s.
+        /// - parameter precision: The percentage of pixels that must match. A value of `1` means all pixels must match,
+        /// while a value of `0.95` means that 95% of pixels must match.
+        /// - parameter perceptualPrecision: The percentage a pixel must match the source pixel to be considered a match.
+        /// `1` means the pixel must match exactly, while `0.98` means the pixel must be within 2% of the source pixel.
+        static func keyboardAccessibilityImage(
+            menu: UIMenu,
+            useMonochromeSnapshot: Bool = true,
+            drawHierarchyInKeyWindow: Bool = false,
+            precision: Float = 1,
+            perceptualPrecision: Float = 1
+        ) -> Snapshotting {
+            return Snapshotting<UIView, UIImage>.image(
+                drawHierarchyInKeyWindow: drawHierarchyInKeyWindow,
+                precision: precision,
+                perceptualPrecision: perceptualPrecision
+            ).pullback { view in
+                makeSnapshotContainer(
+                    for: view,
+                    menu: menu,
+                    useMonochromeSnapshot: useMonochromeSnapshot,
+                    renderingMode: drawHierarchyInKeyWindow ? .drawHierarchyInRect : .renderLayerInContext
+                )
+            }
         }
     }
 
-    /// Creates a snapshot strategy that renders the view with a legend of keyboard shortcuts from a UIMenu.
-    ///
-    /// This variant uses the provided UIMenu to extract shortcuts with category grouping based on submenu titles.
-    ///
-    /// - parameter menu: The UIMenu containing keyboard shortcuts organized by category.
-    /// - parameter useMonochromeSnapshot: Whether or not the snapshot of the `view` should be monochrome. Using a
-    /// monochrome snapshot makes it more clear where the highlighted elements are, but may make it difficult to
-    /// read certain views. Defaults to `true`.
-    /// - parameter drawHierarchyInKeyWindow: Whether or not to draw the view hierachy in the key window, rather than
-    /// rendering the view's layer. This enables the rendering of `UIAppearance` and `UIVisualEffect`s.
-    /// - parameter precision: The percentage of pixels that must match. A value of `1` means all pixels must match,
-    /// while a value of `0.95` means that 95% of pixels must match.
-    /// - parameter perceptualPrecision: The percentage a pixel must match the source pixel to be considered a match.
-    /// `1` means the pixel must match exactly, while `0.98` means the pixel must be within 2% of the source pixel.
-    static func keyboardAccessibilityImage(
-        menu: UIMenu,
-        useMonochromeSnapshot: Bool = true,
-        drawHierarchyInKeyWindow: Bool = false,
-        precision: Float = 1,
-        perceptualPrecision: Float = 1
-    ) -> Snapshotting {
-        return Snapshotting<UIView, UIImage>.image(
-            drawHierarchyInKeyWindow: drawHierarchyInKeyWindow,
-            precision: precision,
-            perceptualPrecision: perceptualPrecision
-        ).pullback { view in
-            makeSnapshotContainer(
-                for: view,
+    public extension Snapshotting where Value == UIViewController, Format == UIImage {
+        /// Creates a snapshot strategy that renders the view controller's view with a legend of keyboard accessibility information.
+        ///
+        /// This variant parses shortcuts from the view controller's responder chain, without category grouping.
+        ///
+        /// - parameter useMonochromeSnapshot: Whether or not the snapshot of the view should be monochrome. Using a
+        /// monochrome snapshot makes it more clear where the highlighted elements are, but may make it difficult to
+        /// read certain views. Defaults to `true`.
+        /// - parameter drawHierarchyInKeyWindow: Whether or not to draw the view hierachy in the key window, rather than
+        /// rendering the view's layer. This enables the rendering of `UIAppearance` and `UIVisualEffect`s.
+        static func keyboardAccessibilityImage(
+            useMonochromeSnapshot: Bool = true,
+            drawHierarchyInKeyWindow: Bool = false,
+            precision: Float = 1,
+            perceptualPrecision: Float = 1
+        ) -> Snapshotting {
+            return Snapshotting<UIView, UIImage>.keyboardAccessibilityImage(
+                useMonochromeSnapshot: useMonochromeSnapshot,
+                drawHierarchyInKeyWindow: drawHierarchyInKeyWindow,
+                precision: precision,
+                perceptualPrecision: perceptualPrecision
+            ).pullback { viewController in
+                viewController.view
+            }
+        }
+
+        /// Creates a snapshot strategy that renders the view controller's view with a legend of keyboard shortcuts from a UIMenu.
+        ///
+        /// This variant uses the provided UIMenu to extract shortcuts with category grouping based on submenu titles.
+        ///
+        /// - parameter menu: The UIMenu containing keyboard shortcuts organized by category.
+        /// - parameter useMonochromeSnapshot: Whether or not the snapshot of the view should be monochrome. Using a
+        /// monochrome snapshot makes it more clear where the highlighted elements are, but may make it difficult to
+        /// read certain views. Defaults to `true`.
+        /// - parameter drawHierarchyInKeyWindow: Whether or not to draw the view hierachy in the key window, rather than
+        /// rendering the view's layer. This enables the rendering of `UIAppearance` and `UIVisualEffect`s.
+        /// - parameter precision: The percentage of pixels that must match. A value of `1` means all pixels must match,
+        /// while a value of `0.95` means that 95% of pixels must match.
+        /// - parameter perceptualPrecision: The percentage a pixel must match the source pixel to be considered a match.
+        /// `1` means the pixel must match exactly, while `0.98` means the pixel must be within 2% of the source pixel.
+        static func keyboardAccessibilityImage(
+            menu: UIMenu,
+            useMonochromeSnapshot: Bool = true,
+            drawHierarchyInKeyWindow: Bool = false,
+            precision: Float = 1,
+            perceptualPrecision: Float = 1
+        ) -> Snapshotting {
+            return Snapshotting<UIView, UIImage>.keyboardAccessibilityImage(
                 menu: menu,
                 useMonochromeSnapshot: useMonochromeSnapshot,
-                renderingMode: drawHierarchyInKeyWindow ? .drawHierarchyInRect : .renderLayerInContext
-            )
-        }
-    }
-}
-
-public extension Snapshotting where Value == UIViewController, Format == UIImage {
-    /// Creates a snapshot strategy that renders the view controller's view with a legend of keyboard accessibility information.
-    ///
-    /// This variant parses shortcuts from the view controller's responder chain, without category grouping.
-    ///
-    /// - parameter useMonochromeSnapshot: Whether or not the snapshot of the view should be monochrome. Using a
-    /// monochrome snapshot makes it more clear where the highlighted elements are, but may make it difficult to
-    /// read certain views. Defaults to `true`.
-    /// - parameter drawHierarchyInKeyWindow: Whether or not to draw the view hierachy in the key window, rather than
-    /// rendering the view's layer. This enables the rendering of `UIAppearance` and `UIVisualEffect`s.
-    static func keyboardAccessibilityImage(
-        useMonochromeSnapshot: Bool = true,
-        drawHierarchyInKeyWindow: Bool = false,
-        precision: Float = 1,
-        perceptualPrecision: Float = 1
-    ) -> Snapshotting {
-        return Snapshotting<UIView, UIImage>.keyboardAccessibilityImage(
-            useMonochromeSnapshot: useMonochromeSnapshot,
-            drawHierarchyInKeyWindow: drawHierarchyInKeyWindow,
-            precision: precision,
-            perceptualPrecision: perceptualPrecision
-        ).pullback { viewController in
-            viewController.view
+                drawHierarchyInKeyWindow: drawHierarchyInKeyWindow,
+                precision: precision,
+                perceptualPrecision: perceptualPrecision
+            ).pullback { viewController in
+                viewController.view
+            }
         }
     }
 
-    /// Creates a snapshot strategy that renders the view controller's view with a legend of keyboard shortcuts from a UIMenu.
-    ///
-    /// This variant uses the provided UIMenu to extract shortcuts with category grouping based on submenu titles.
-    ///
-    /// - parameter menu: The UIMenu containing keyboard shortcuts organized by category.
-    /// - parameter useMonochromeSnapshot: Whether or not the snapshot of the view should be monochrome. Using a
-    /// monochrome snapshot makes it more clear where the highlighted elements are, but may make it difficult to
-    /// read certain views. Defaults to `true`.
-    /// - parameter drawHierarchyInKeyWindow: Whether or not to draw the view hierachy in the key window, rather than
-    /// rendering the view's layer. This enables the rendering of `UIAppearance` and `UIVisualEffect`s.
-    /// - parameter precision: The percentage of pixels that must match. A value of `1` means all pixels must match,
-    /// while a value of `0.95` means that 95% of pixels must match.
-    /// - parameter perceptualPrecision: The percentage a pixel must match the source pixel to be considered a match.
-    /// `1` means the pixel must match exactly, while `0.98` means the pixel must be within 2% of the source pixel.
-    static func keyboardAccessibilityImage(
-        menu: UIMenu,
-        useMonochromeSnapshot: Bool = true,
-        drawHierarchyInKeyWindow: Bool = false,
-        precision: Float = 1,
-        perceptualPrecision: Float = 1
-    ) -> Snapshotting {
-        return Snapshotting<UIView, UIImage>.keyboardAccessibilityImage(
+    public extension Snapshotting where Value: SwiftUI.View, Format == UIImage {
+        /// Creates a snapshot strategy for SwiftUI views with keyboard accessibility information.
+        ///
+        /// This variant parses shortcuts from the view's responder chain, without category grouping.
+        ///
+        /// - parameter useMonochromeSnapshot: Whether or not the snapshot of the view should be monochrome. Using a
+        /// monochrome snapshot makes it more clear where the highlighted elements are, but may make it difficult to
+        /// read certain views. Defaults to `true`.
+        /// - parameter precision: The percentage of pixels that must match. A value of `1` means all pixels must match,
+        /// while a value of `0.95` means that 95% of pixels must match.
+        /// - parameter perceptualPrecision: The percentage a pixel must match the source pixel to be considered a match.
+        /// `1` means the pixel must match exactly, while `0.98` means the pixel must be within 2% of the source pixel.
+        static func keyboardAccessibilityImage(
+            useMonochromeSnapshot: Bool = true,
+            precision: Float = 1,
+            perceptualPrecision: Float = 1
+        ) -> Snapshotting {
+            return Snapshotting<UIImage, UIImage>.image(precision: precision, perceptualPrecision: perceptualPrecision).pullback { (view: Value) in
+                makeSwiftUISnapshot(view: view, menu: nil, useMonochromeSnapshot: useMonochromeSnapshot)
+            }
+        }
+
+        /// Creates a snapshot strategy for SwiftUI views with keyboard shortcuts from a UIMenu.
+        ///
+        /// This variant uses the provided UIMenu to extract shortcuts with category grouping based on submenu titles.
+        ///
+        /// - parameter menu: The UIMenu containing keyboard shortcuts organized by category.
+        /// - parameter useMonochromeSnapshot: Whether or not the snapshot of the view should be monochrome. Using a
+        /// monochrome snapshot makes it more clear where the highlighted elements are, but may make it difficult to
+        /// read certain views. Defaults to `true`.
+        /// - parameter precision: The percentage of pixels that must match. A value of `1` means all pixels must match,
+        /// while a value of `0.95` means that 95% of pixels must match.
+        /// - parameter perceptualPrecision: The percentage a pixel must match the source pixel to be considered a match.
+        /// `1` means the pixel must match exactly, while `0.98` means the pixel must be within 2% of the source pixel.
+        static func keyboardAccessibilityImage(
+            menu: UIMenu,
+            useMonochromeSnapshot: Bool = true,
+            precision: Float = 1,
+            perceptualPrecision: Float = 1
+        ) -> Snapshotting {
+            return Snapshotting<UIImage, UIImage>.image(precision: precision, perceptualPrecision: perceptualPrecision).pullback { (view: Value) in
+                makeSwiftUISnapshot(view: view, menu: menu, useMonochromeSnapshot: useMonochromeSnapshot)
+            }
+        }
+    }
+
+    private func makeSwiftUISnapshot<V: SwiftUI.View>(
+        view: V,
+        menu: UIMenu?,
+        useMonochromeSnapshot: Bool
+    ) -> UIImage {
+        let hostingController = UIHostingController(rootView: view)
+        let hostingView = hostingController.view!
+        hostingView.bounds.size = hostingController.sizeThatFits(in: .zero)
+
+        // Add to window to ensure responder chain is set up for keyboard shortcut discovery
+        let window = UIWindow(frame: hostingView.bounds)
+        window.rootViewController = hostingController
+        window.makeKeyAndVisible()
+
+        hostingView.setNeedsLayout()
+        hostingView.layoutIfNeeded()
+
+        let containerView = makeSnapshotContainer(
+            for: hostingView,
             menu: menu,
             useMonochromeSnapshot: useMonochromeSnapshot,
-            drawHierarchyInKeyWindow: drawHierarchyInKeyWindow,
-            precision: precision,
-            perceptualPrecision: perceptualPrecision
-        ).pullback { viewController in
-            viewController.view
+            renderingMode: .drawHierarchyInRect
+        )
+
+        return containerView.renderToImage() ?? UIImage()
+    }
+
+    private func makeSnapshotContainer(
+        for view: UIView,
+        menu: UIMenu?,
+        useMonochromeSnapshot: Bool,
+        renderingMode: KeyboardAccessibilitySnapshotView.ViewRenderingMode
+    ) -> KeyboardAccessibilitySnapshotView {
+        let containerView = KeyboardAccessibilitySnapshotView(
+            containedView: view,
+            viewRenderingMode: renderingMode,
+            useMonochromeSnapshot: useMonochromeSnapshot
+        )
+
+        do {
+            if let menu = menu {
+                try containerView.parseKeyboardShortcuts(from: menu)
+            } else {
+                try containerView.parseKeyboardShortcuts()
+            }
+        } catch {
+            fatalError("Failed to parse keyboard shortcuts: \(error)")
+        }
+
+        let size = containerView.sizeThatFits(.zero)
+        containerView.frame = CGRect(origin: .zero, size: size)
+        containerView.layoutIfNeeded()
+        return containerView
+    }
+
+    private extension UIView {
+        func renderToImage() -> UIImage? {
+            UIGraphicsBeginImageContextWithOptions(bounds.size, false, 0)
+            defer { UIGraphicsEndImageContext() }
+            drawHierarchy(in: bounds, afterScreenUpdates: true)
+            return UIGraphicsGetImageFromCurrentImageContext()
         }
     }
-}
 
-public extension Snapshotting where Value: SwiftUI.View, Format == UIImage {
-    /// Creates a snapshot strategy for SwiftUI views with keyboard accessibility information.
-    ///
-    /// This variant parses shortcuts from the view's responder chain, without category grouping.
-    ///
-    /// - parameter useMonochromeSnapshot: Whether or not the snapshot of the view should be monochrome. Using a
-    /// monochrome snapshot makes it more clear where the highlighted elements are, but may make it difficult to
-    /// read certain views. Defaults to `true`.
-    /// - parameter precision: The percentage of pixels that must match. A value of `1` means all pixels must match,
-    /// while a value of `0.95` means that 95% of pixels must match.
-    /// - parameter perceptualPrecision: The percentage a pixel must match the source pixel to be considered a match.
-    /// `1` means the pixel must match exactly, while `0.98` means the pixel must be within 2% of the source pixel.
-    static func keyboardAccessibilityImage(
-        useMonochromeSnapshot: Bool = true,
-        precision: Float = 1,
-        perceptualPrecision: Float = 1
-    ) -> Snapshotting {
-        return Snapshotting<UIImage, UIImage>.image(precision: precision, perceptualPrecision: perceptualPrecision).pullback { (view: Value) in
-            makeSwiftUISnapshot(view: view, menu: nil, useMonochromeSnapshot: useMonochromeSnapshot)
-        }
-    }
-
-    /// Creates a snapshot strategy for SwiftUI views with keyboard shortcuts from a UIMenu.
-    ///
-    /// This variant uses the provided UIMenu to extract shortcuts with category grouping based on submenu titles.
-    ///
-    /// - parameter menu: The UIMenu containing keyboard shortcuts organized by category.
-    /// - parameter useMonochromeSnapshot: Whether or not the snapshot of the view should be monochrome. Using a
-    /// monochrome snapshot makes it more clear where the highlighted elements are, but may make it difficult to
-    /// read certain views. Defaults to `true`.
-    /// - parameter precision: The percentage of pixels that must match. A value of `1` means all pixels must match,
-    /// while a value of `0.95` means that 95% of pixels must match.
-    /// - parameter perceptualPrecision: The percentage a pixel must match the source pixel to be considered a match.
-    /// `1` means the pixel must match exactly, while `0.98` means the pixel must be within 2% of the source pixel.
-    static func keyboardAccessibilityImage(
-        menu: UIMenu,
-        useMonochromeSnapshot: Bool = true,
-        precision: Float = 1,
-        perceptualPrecision: Float = 1
-    ) -> Snapshotting {
-        return Snapshotting<UIImage, UIImage>.image(precision: precision, perceptualPrecision: perceptualPrecision).pullback { (view: Value) in
-            makeSwiftUISnapshot(view: view, menu: menu, useMonochromeSnapshot: useMonochromeSnapshot)
-        }
-    }
-}
-
-private func makeSwiftUISnapshot<V: SwiftUI.View>(
-    view: V,
-    menu: UIMenu?,
-    useMonochromeSnapshot: Bool
-) -> UIImage {
-    let hostingController = UIHostingController(rootView: view)
-    let hostingView = hostingController.view!
-    hostingView.bounds.size = hostingController.sizeThatFits(in: .zero)
-
-    // Add to window to ensure responder chain is set up for keyboard shortcut discovery
-    let window = UIWindow(frame: hostingView.bounds)
-    window.rootViewController = hostingController
-    window.makeKeyAndVisible()
-
-    hostingView.setNeedsLayout()
-    hostingView.layoutIfNeeded()
-
-    let containerView = makeSnapshotContainer(
-        for: hostingView,
-        menu: menu,
-        useMonochromeSnapshot: useMonochromeSnapshot,
-        renderingMode: .drawHierarchyInRect
-    )
-
-    return containerView.renderToImage() ?? UIImage()
-}
-
-private func makeSnapshotContainer(
-    for view: UIView,
-    menu: UIMenu?,
-    useMonochromeSnapshot: Bool,
-    renderingMode: KeyboardAccessibilitySnapshotView.ViewRenderingMode
-) -> KeyboardAccessibilitySnapshotView {
-    let containerView = KeyboardAccessibilitySnapshotView(
-        containedView: view,
-        viewRenderingMode: renderingMode,
-        useMonochromeSnapshot: useMonochromeSnapshot
-    )
-
-    do {
-        if let menu = menu {
-            try containerView.parseKeyboardShortcuts(from: menu)
-        } else {
-            try containerView.parseKeyboardShortcuts()
-        }
-    } catch {
-        fatalError("Failed to parse keyboard shortcuts: \(error)")
-    }
-
-    let size = containerView.sizeThatFits(.zero)
-    containerView.frame = CGRect(origin: .zero, size: size)
-    containerView.layoutIfNeeded()
-    return containerView
-}
-
-private extension UIView {
-    func renderToImage() -> UIImage? {
-        UIGraphicsBeginImageContextWithOptions(bounds.size, false, 0)
-        defer { UIGraphicsEndImageContext() }
-        drawHierarchy(in: bounds, afterScreenUpdates: true)
-        return UIGraphicsGetImageFromCurrentImageContext()
-    }
-}
+#endif

--- a/Sources/AccessibilitySnapshot/SnapshotTesting/SnapshotTesting+SwiftUI.swift
+++ b/Sources/AccessibilitySnapshot/SnapshotTesting/SnapshotTesting+SwiftUI.swift
@@ -1,84 +1,90 @@
-import AccessibilitySnapshotCore
-import AccessibilitySnapshotParser_ObjC
-import SnapshotTesting
-import SwiftUI
-import UIKit
+// See the note in SnapshotTesting+Accessibility.swift: swift-snapshot-testing's UIKit image strategies are iOS/tvOS
+// only, so these strategies are as well.
+#if os(iOS) || os(tvOS)
 
-public extension Snapshotting where Value: SwiftUI.View, Format == UIImage {
-    /// Snapshots the current view with colored overlays of each accessibility element it contains, as well as an
-    /// approximation of the description that VoiceOver will read for each element.
-    static var accessibilityImage: Snapshotting {
-        return .accessibilityImage()
+    import AccessibilitySnapshotCore
+    import AccessibilitySnapshotParser_ObjC
+    import SnapshotTesting
+    import SwiftUI
+    import UIKit
+
+    public extension Snapshotting where Value: SwiftUI.View, Format == UIImage {
+        /// Snapshots the current view with colored overlays of each accessibility element it contains, as well as an
+        /// approximation of the description that VoiceOver will read for each element.
+        static var accessibilityImage: Snapshotting {
+            return .accessibilityImage()
+        }
+
+        /// Snapshots the current view with colored overlays of each accessibility element it contains, as well as an
+        /// approximation of the description that VoiceOver will read for each element.
+        ///
+        /// - parameter size: The size of the snapshotted view. Note this size does not include the legend. Pass `nil` to
+        /// use the view's size that fits.
+        /// - parameter showActivationPoints: When to show indicators for elements' accessibility activation points.
+        /// Defaults to showing activation points only when they are different than the default activation point for that
+        /// element.
+        /// - parameter useMonochromeSnapshot: Whether or not the snapshot of the view should be monochrome. Using a
+        /// monochrome snapshot makes it more clear where the highlighted elements are, but may make it difficult to
+        /// read certain views. Defaults to `true`.
+        /// - parameter drawHierarchyInKeyWindow: Whether or not to draw the view hierachy in the key window, rather than
+        /// rendering the view's layer. This enables the rendering of `UIAppearance` and `UIVisualEffect`s.
+        /// - parameter markerColors: The array of colors which will be chosen from when creating the overlays.
+        /// - parameter showUserInputLabels: Controls when to show elements' accessibility user input labels (used by Voice
+        /// Control).
+        /// - parameter precision: The percentage of pixels that must match. A value of `1` means all pixels must match,
+        /// while a value of `0.95` means that 95% of pixels must match.
+        /// - parameter perceptualPrecision: The percentage a pixel must match the source pixel to be considered a match.
+        /// `1` means the pixel must match exactly, while `0.98` means the pixel must be within 2% of the source pixel.
+        static func accessibilityImage(
+            size: CGSize? = nil,
+            showActivationPoints activationPointDisplayMode: AccessibilityContentDisplayMode = .whenOverridden,
+            useMonochromeSnapshot: Bool = true,
+            drawHierarchyInKeyWindow: Bool = false,
+            markerColors: [UIColor] = [],
+            showUserInputLabels: Bool = true,
+            shouldRunInHostApplication: Bool = true,
+            precision: Float = 1,
+            perceptualPrecision: Float = 1
+        ) -> Snapshotting {
+            return Snapshotting<UIViewController, UIImage>
+                .accessibilityImage(
+                    showActivationPoints: activationPointDisplayMode,
+                    useMonochromeSnapshot: useMonochromeSnapshot,
+                    drawHierarchyInKeyWindow: drawHierarchyInKeyWindow,
+                    markerColors: markerColors,
+                    showUserInputLabels: showUserInputLabels,
+                    shouldRunInHostApplication: shouldRunInHostApplication,
+                    precision: precision,
+                    perceptualPrecision: perceptualPrecision
+                )
+                .pullback { (view: Value) in
+                    let hostingController = UIHostingController(rootView: view)
+                    hostingController.view.bounds.size = size ?? hostingController.sizeThatFits(in: .zero)
+                    return hostingController
+                }
+        }
+
+        /// Snapshots the view simulating the way it will appear with Smart Invert Colors enabled.
+        static var imageWithSmartInvert: Snapshotting {
+            return .imageWithSmartInvert()
+        }
+
+        /// Snapshots the view simulating the way it will appear with Smart Invert Colors enabled.
+        ///
+        /// - parameter precision: The percentage of pixels that must match. A value of `1` means all pixels must match,
+        /// while a value of `0.95` means that 95% of pixels must match.
+        /// - parameter perceptualPrecision: The percentage a pixel must match the source pixel to be considered a match.
+        /// `1` means the pixel must match exactly, while `0.98` means the pixel must be within 2% of the source pixel.
+        static func imageWithSmartInvert(
+            precision: Float = 1,
+            perceptualPrecision: Float = 1
+        ) -> Snapshotting {
+            return Snapshotting<UIViewController, UIImage>
+                .imageWithSmartInvert(precision: precision, perceptualPrecision: perceptualPrecision)
+                .pullback { (view: Value) in
+                    UIHostingController(rootView: view)
+                }
+        }
     }
 
-    /// Snapshots the current view with colored overlays of each accessibility element it contains, as well as an
-    /// approximation of the description that VoiceOver will read for each element.
-    ///
-    /// - parameter size: The size of the snapshotted view. Note this size does not include the legend. Pass `nil` to
-    /// use the view's size that fits.
-    /// - parameter showActivationPoints: When to show indicators for elements' accessibility activation points.
-    /// Defaults to showing activation points only when they are different than the default activation point for that
-    /// element.
-    /// - parameter useMonochromeSnapshot: Whether or not the snapshot of the view should be monochrome. Using a
-    /// monochrome snapshot makes it more clear where the highlighted elements are, but may make it difficult to
-    /// read certain views. Defaults to `true`.
-    /// - parameter drawHierarchyInKeyWindow: Whether or not to draw the view hierachy in the key window, rather than
-    /// rendering the view's layer. This enables the rendering of `UIAppearance` and `UIVisualEffect`s.
-    /// - parameter markerColors: The array of colors which will be chosen from when creating the overlays.
-    /// - parameter showUserInputLabels: Controls when to show elements' accessibility user input labels (used by Voice
-    /// Control).
-    /// - parameter precision: The percentage of pixels that must match. A value of `1` means all pixels must match,
-    /// while a value of `0.95` means that 95% of pixels must match.
-    /// - parameter perceptualPrecision: The percentage a pixel must match the source pixel to be considered a match.
-    /// `1` means the pixel must match exactly, while `0.98` means the pixel must be within 2% of the source pixel.
-    static func accessibilityImage(
-        size: CGSize? = nil,
-        showActivationPoints activationPointDisplayMode: AccessibilityContentDisplayMode = .whenOverridden,
-        useMonochromeSnapshot: Bool = true,
-        drawHierarchyInKeyWindow: Bool = false,
-        markerColors: [UIColor] = [],
-        showUserInputLabels: Bool = true,
-        shouldRunInHostApplication: Bool = true,
-        precision: Float = 1,
-        perceptualPrecision: Float = 1
-    ) -> Snapshotting {
-        return Snapshotting<UIViewController, UIImage>
-            .accessibilityImage(
-                showActivationPoints: activationPointDisplayMode,
-                useMonochromeSnapshot: useMonochromeSnapshot,
-                drawHierarchyInKeyWindow: drawHierarchyInKeyWindow,
-                markerColors: markerColors,
-                showUserInputLabels: showUserInputLabels,
-                shouldRunInHostApplication: shouldRunInHostApplication,
-                precision: precision,
-                perceptualPrecision: perceptualPrecision
-            )
-            .pullback { (view: Value) in
-                let hostingController = UIHostingController(rootView: view)
-                hostingController.view.bounds.size = size ?? hostingController.sizeThatFits(in: .zero)
-                return hostingController
-            }
-    }
-
-    /// Snapshots the view simulating the way it will appear with Smart Invert Colors enabled.
-    static var imageWithSmartInvert: Snapshotting {
-        return .imageWithSmartInvert()
-    }
-
-    /// Snapshots the view simulating the way it will appear with Smart Invert Colors enabled.
-    ///
-    /// - parameter precision: The percentage of pixels that must match. A value of `1` means all pixels must match,
-    /// while a value of `0.95` means that 95% of pixels must match.
-    /// - parameter perceptualPrecision: The percentage a pixel must match the source pixel to be considered a match.
-    /// `1` means the pixel must match exactly, while `0.98` means the pixel must be within 2% of the source pixel.
-    static func imageWithSmartInvert(
-        precision: Float = 1,
-        perceptualPrecision: Float = 1
-    ) -> Snapshotting {
-        return Snapshotting<UIViewController, UIImage>
-            .imageWithSmartInvert(precision: precision, perceptualPrecision: perceptualPrecision)
-            .pullback { (view: Value) in
-                UIHostingController(rootView: view)
-            }
-    }
-}
+#endif


### PR DESCRIPTION

Fixes #349.

Draft for reference alongside the discussion in #349 — happy to reshape it based on the
answers there (e.g. platform conditionals instead of replacing the `UIScreen` reads, or
holding for the swift-snapshot-testing strategy story).

## What this does

- **`Package.swift`**: bumps swift-tools-version to 5.9 and declares `.visionOS(.v1)`.
  The bump required migrating the two remote dependencies off the deprecated
  `.package(name:url:)` form; target dependencies now reference the products by package
  identity.
- **Removes all `UIScreen` usage from the visionOS-supported targets.**
  `UIView.effectiveDisplayScale` (in `AccessibilitySnapshotParser`) reads the scale from
  the view's trait environment, and `SnapshotPlatformDefaults` (in
  `AccessibilitySnapshotCore`) supplies the host-window frame that previously came from
  `UIScreen.main.bounds`, with an explicit 1280×720 default on visionOS. This also
  removes the deprecated `UIWindow.screen` reads in `SnapshotAndLegendView`.
- **Gates the three SnapshotTesting strategy files to `#if os(iOS) || os(tvOS)`** —
  swift-snapshot-testing only vends its UIKit image strategies on those platforms. The
  `AccessibilitySnapshot` product builds for visionOS but vends no strategies there yet;
  the parser, core rendering, and previews layers are fully available.
- **`FBSnapshotTestCase-Accessibility(-ObjC)` remain iOS-only** (`ios-snapshot-test-case`
  does not support visionOS).
- **CI**: `Scripts/build.swift` gains a `visionOS_26` platform (build-only,
  `generic/platform=visionOS Simulator`, `xrsimulator` SDK) and the `spm` job builds it
  in a matrix alongside iOS.
- No behavior change on iOS: `traitCollection.displayScale` matches the previous
  `UIScreen`-derived scale, and the default host-window frame is unchanged there.

## Notes

- `ASAccessibilityEnabler` needs no changes: the visionOS simulator runtime ships
  `usr/lib/libAccessibility.dylib` exporting the automation symbols, and CoreSimulator
  sets `IPHONE_SIMULATOR_ROOT` on visionOS simulators just as on iOS.
- `UIAccessibilityStatusUtility` (Smart Invert mocking) compiles for visionOS but is
  unreachable there while the strategies are gated; runtime validation is a follow-up.

## Testing

- Full existing iOS snapshot suites pass unchanged (iOS 17.5 / 18.5 / 26.2 lanes) — the
  display-scale refactor produced zero reference-image diffs.
- The new visionOS lane builds all visionOS-supported products against the visionOS
  simulator SDK.
- `swift test` on `AccessibilitySnapshotModel` passes.

## Follow-ups (intentionally not in this PR)

- visionOS reference images and test targets.
- Smart Invert (fishhook) runtime validation on visionOS.
- visionOS destinations in the Tuist example project (needs the `iOSSnapshotTestCase`
  dependency split out of the example targets first).
- A visionOS `Snapshotting` strategy story, pending upstream support in
  swift-snapshot-testing (open PR: pointfreeco/swift-snapshot-testing#1116; alternatively
  a local base-strategy implementation). Once that lands, the `#if os(iOS) || os(tvOS)`
  gates here can widen to include visionOS.
