### PR TITLE
Fix versioned SwiftPM package resolution

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -37,7 +37,6 @@ let package = Package(
         ),
     ],
     dependencies: [
-        .package(path: "AccessibilitySnapshotModel"),
         .package(
             name: "iOSSnapshotTestCase",
             url: "https://github.com/uber/ios-snapshot-test-case.git",
@@ -51,13 +50,17 @@ let package = Package(
     ],
     targets: [
         .target(
+            name: "AccessibilitySnapshotModel",
+            path: "AccessibilitySnapshotModel/Sources/AccessibilitySnapshotModel"
+        ),
+        .target(
             name: "AccessibilitySnapshotParser-ObjC",
             path: "Sources/AccessibilitySnapshot/Parser/ObjC"
         ),
         .target(
             name: "AccessibilitySnapshotParser",
             dependencies: [
-                .product(name: "AccessibilitySnapshotModel", package: "AccessibilitySnapshotModel"),
+                "AccessibilitySnapshotModel",
                 "AccessibilitySnapshotParser-ObjC",
             ],
             path: "Sources/AccessibilitySnapshot/Parser/Swift",


### PR DESCRIPTION
(Kyle says: I found this when going down a rabbit hole of trying to get SPM to point at main and it wouldn't, this all seems right from some testing but this is also a 100% slop PR; close / ignore if I am missing something!)

> _Posted by an AI agent on kyleve's behalf._

## Summary

- consume the portable `AccessibilitySnapshotModel` sources as an internal target of the root package
- retain the standalone model package and its platform-independent test suite
- allow tagged AccessibilitySnapshot releases to resolve as stable SwiftPM dependencies

## Why

The root package currently declares `AccessibilitySnapshotModel` with `.package(path:)`. SwiftPM classifies that nested dependency as unstable and rejects any semantic-version tag made from the current `main` branch:

```
package 'accessibilitysnapshot' is required using a stable-version but
'accessibilitysnapshot' depends on an unstable-version package
'accessibilitysnapshotmodel'
```

Referencing the existing source directory as an internal root-package target preserves the standalone package introduced in #339 while making the root dependency graph valid for versioned consumers.

## Testing

- `swift test --package-path AccessibilitySnapshotModel` — 13 tests passed
- `swift package resolve`
- `swiftformat --lint Package.swift`
- created a local semantic-version tag for this commit and resolved `AccessibilitySnapshotPreviews` from a temporary consumer using `.package(url:exact:)`
