### PR TITLE
[DNR] Allow accessibility descriptions to wrap in SwiftUI previews

### DIFF
--- a/Example/AccessibilitySnapshotPreviewsTests/DescriptionViewTests.swift
+++ b/Example/AccessibilitySnapshotPreviewsTests/DescriptionViewTests.swift
@@ -1,0 +1,46 @@
+import AccessibilitySnapshotCore
+@testable import AccessibilitySnapshotPreviews
+import UIKit
+import XCTest
+
+@available(iOS 16.0, *)
+final class DescriptionViewTests: XCTestCase {
+    @MainActor
+    func testLongDescriptionWrapsInRenderedLegend() throws {
+        let singleLineHeight = try renderedHeight(
+            accessibilityValue: "California: 132 days"
+        )
+        let multilineHeight = try renderedHeight(
+            accessibilityValue: "California: 132 days, New York: 41 days, Canada: 9 days, and European Union: 4 days"
+        )
+
+        XCTAssertGreaterThan(multilineHeight, singleLineHeight)
+    }
+
+    @MainActor
+    private func renderedHeight(accessibilityValue: String) throws -> CGFloat {
+        let renderSize = CGSize(width: 402, height: 158)
+        let content = UIView(frame: CGRect(origin: .zero, size: renderSize))
+        content.backgroundColor = .white
+        content.isAccessibilityElement = true
+        content.accessibilityLabel = "Days in 2026"
+        content.accessibilityValue = accessibilityValue
+
+        let container = SwiftUIAccessibilitySnapshotContainerView(
+            containedView: content,
+            snapshotConfiguration: AccessibilitySnapshotConfiguration(
+                viewRenderingMode: .drawHierarchyInRect
+            )
+        )
+        let window = UIWindow(frame: UIScreen.main.bounds)
+        window.makeKeyAndVisible()
+        container.center = window.center
+        window.addSubview(container)
+        defer { window.isHidden = true }
+
+        try container.parseAccessibility()
+        container.sizeToFit()
+
+        return container.bounds.height
+    }
+}

--- a/Example/Project.swift
+++ b/Example/Project.swift
@@ -290,6 +290,8 @@ let project = Project(
             sources: ["AccessibilitySnapshotPreviewsTests/**/*.swift"],
             dependencies: [
                 .target(name: "AccessibilitySnapshotPreviewsDemo"),
+                .target(name: "AccessibilitySnapshotPreviews"),
+                .target(name: "AccessibilitySnapshotCore"),
                 .target(name: "FBSnapshotTestCase_Accessibility"),
                 .external(name: "iOSSnapshotTestCase"),
                 .xctest,

--- a/Sources/AccessibilitySnapshot/AccessibilitySnapshotPreviews/DescriptionView.swift
+++ b/Sources/AccessibilitySnapshot/AccessibilitySnapshotPreviews/DescriptionView.swift
@@ -10,6 +10,7 @@ struct DescriptionView: View {
             .font(DesignTokens.Typography.description)
             .foregroundColor(DesignTokens.Colors.primaryText)
             .lineLimit(nil)
+            .fixedSize(horizontal: false, vertical: true)
     }
 }
 


### PR DESCRIPTION
(Sorry my agents did uh, something, lemme check on this one...)

> _Posted by an AI agent on kyleve’s behalf._

## Summary

- let SwiftUI accessibility descriptions report their multiline intrinsic height
- add an integration regression through SwiftUIAccessibilitySnapshotContainerView
- compare single-line and multiline legend heights so the test is independent of pixel reference images

Closes #354.

## Testing

- focused AccessibilitySnapshotPreviewsTests/DescriptionViewTests on an iOS 27 simulator (passes with the fix; confirmed failing without it)
- SwiftFormat lint on the three changed files
- git diff --check

## Notes

Repository-wide SwiftFormat lint currently reports pre-existing findings in unrelated demo, generated, and source files; the changed files are clean.