### PR TITLE
[DNR] Preserve view controller containment during accessibility snapshots

### DIFF
--- a/Example/AccessibilitySnapshotPreviewsTests/OverlayAlignmentTests.swift
+++ b/Example/AccessibilitySnapshotPreviewsTests/OverlayAlignmentTests.swift
@@ -1,0 +1,383 @@
+import AccessibilitySnapshotCore
+import AccessibilitySnapshotModel
+import AccessibilitySnapshotParser
+@testable import AccessibilitySnapshotPreviews
+import SwiftUI
+import UIKit
+import XCTest
+
+@available(iOS 18.0, *)
+@MainActor
+final class OverlayAlignmentTests: XCTestCase {
+    private let renderSize = CGSize(width: 300, height: 350)
+
+    func testUIKitFrameMatchesParsedFrameInScreenCoordinates() throws {
+        let root = UIView(frame: CGRect(origin: .zero, size: renderSize))
+        let element = UIView(frame: CGRect(x: 50, y: 100, width: 200, height: 50))
+        element.isAccessibilityElement = true
+        element.accessibilityLabel = "UIKit probe"
+        root.addSubview(element)
+
+        let window = host(root)
+        defer { window.isHidden = true }
+
+        let marker = try parsedMarker(label: "UIKit probe", in: root)
+        assertEqual(
+            element.convert(element.bounds, to: nil),
+            root.convert(marker.shape.boundingBox, to: nil)
+        )
+    }
+
+    func testSwiftUIFrameMatchesParsedPathInScreenCoordinates() throws {
+        try assertSwiftUIAlignment(topSpacing: 100, wrapperInset: 0, safeAreaTop: 0)
+    }
+
+    func testSwiftUIFrameMatchesWithNonzeroSafeArea() throws {
+        try assertSwiftUIAlignment(topSpacing: 100, wrapperInset: 0, safeAreaTop: 12)
+    }
+
+    func testSwiftUIFrameMatchesAfterInsetWrapperReparenting() throws {
+        try assertSwiftUIAlignment(topSpacing: 100, wrapperInset: 8, safeAreaTop: 0)
+    }
+
+    func testSwiftUIFrameMatchesAfterTiledHierarchyRendering() throws {
+        try assertSwiftUIAlignment(topSpacing: 2100, wrapperInset: 8, safeAreaTop: 12)
+    }
+
+    func testFrameOverlayPreservesMarkerCenterAndAppliesSymmetricOutset() throws {
+        let markerFrame = CGRect(x: 50, y: 100, width: 200, height: 50)
+        let overlayFrame = try resolvedOverlayFrame(for: .frame(AccessibilityRect(markerFrame)))
+        let expectedFrame = markerFrame.insetBy(dx: -2, dy: -2)
+
+        XCTAssertEqual(overlayFrame.midX, expectedFrame.midX, accuracy: 1)
+        XCTAssertEqual(overlayFrame.midY, expectedFrame.midY, accuracy: 1)
+        XCTAssertEqual(overlayFrame.width, expectedFrame.width, accuracy: 2)
+        XCTAssertEqual(overlayFrame.height, expectedFrame.height, accuracy: 2)
+    }
+
+    func testRectangularPathOverlayPreservesMarkerCenterAndAppliesSymmetricOutset() throws {
+        let markerFrame = CGRect(x: 50, y: 100, width: 200, height: 50)
+        let path = UIBezierPath(rect: markerFrame)
+        let shape = AccessibilityShape.path(AccessibilityPathElement.elements(from: path.cgPath))
+        let overlayFrame = try resolvedOverlayFrame(for: shape)
+        let expectedFrame = markerFrame.insetBy(dx: -2, dy: -2)
+
+        XCTAssertEqual(overlayFrame.midX, expectedFrame.midX, accuracy: 1)
+        XCTAssertEqual(overlayFrame.midY, expectedFrame.midY, accuracy: 1)
+        XCTAssertEqual(overlayFrame.width, expectedFrame.width, accuracy: 2)
+        XCTAssertEqual(overlayFrame.height, expectedFrame.height, accuracy: 2)
+    }
+
+    private func assertSwiftUIAlignment(
+        topSpacing: CGFloat,
+        wrapperInset: CGFloat,
+        safeAreaTop: CGFloat
+    ) throws {
+        let anchor = AnchorBox()
+        let contentHeight = max(renderSize.height, topSpacing + 150)
+        let root = VStack(spacing: 0) {
+            Color.clear.frame(height: topSpacing)
+            AnchorView(box: anchor)
+                .frame(width: 200, height: 50)
+                .background(Color.black)
+                .accessibilityElement(children: .ignore)
+                .accessibilityLabel("SwiftUI probe")
+            Spacer(minLength: 0)
+        }
+        .frame(width: renderSize.width, height: contentHeight, alignment: .top)
+        .background(Color.white)
+
+        let hosting = UIHostingController(rootView: root)
+        hosting.additionalSafeAreaInsets.top = safeAreaTop
+        hosting.view.frame = CGRect(x: 0, y: 0, width: renderSize.width, height: contentHeight)
+        let containedView: UIView
+        if wrapperInset > 0 {
+            let wrapper = UIView(
+                frame: CGRect(
+                    x: 0,
+                    y: 0,
+                    width: renderSize.width + wrapperInset * 2,
+                    height: contentHeight + wrapperInset * 2
+                )
+            )
+            wrapper.backgroundColor = .white
+            hosting.view.frame.origin = CGPoint(x: wrapperInset, y: wrapperInset)
+            wrapper.addSubview(hosting.view)
+            containedView = wrapper
+        } else {
+            containedView = hosting.view
+        }
+
+        var liveFrame: CGRect?
+        var markerFrame: CGRect?
+        var renderedProbeFrame: CGRect?
+        let container = CapturingSnapshotView(
+            containedView: containedView,
+            snapshotConfiguration: AccessibilitySnapshotConfiguration(
+                viewRenderingMode: .drawHierarchyInRect,
+                colorRenderingMode: .fullColor
+            )
+        ) { data in
+            liveFrame = anchor.view?.convert(anchor.view?.bounds ?? .zero, to: nil)
+            if let marker = data.markers.first(where: { $0.label == "SwiftUI probe" }) {
+                markerFrame = containedView.convert(marker.shape.boundingBox, to: nil)
+                renderedProbeFrame = self.blackPixelBounds(in: data.image)
+                if let renderedProbeFrame {
+                    XCTAssertEqual(
+                        renderedProbeFrame.midX,
+                        marker.shape.boundingBox.midX,
+                        accuracy: 1
+                    )
+                    XCTAssertEqual(
+                        renderedProbeFrame.midY,
+                        marker.shape.boundingBox.midY,
+                        accuracy: 1
+                    )
+                    XCTAssertLessThanOrEqual(
+                        abs(renderedProbeFrame.width - marker.shape.boundingBox.width),
+                        2
+                    )
+                    XCTAssertLessThanOrEqual(
+                        abs(renderedProbeFrame.height - marker.shape.boundingBox.height),
+                        2
+                    )
+                }
+            }
+        }
+
+        let window = host(container)
+        defer { window.isHidden = true }
+        try container.parseAccessibility()
+
+        let resolvedLiveFrame = try XCTUnwrap(liveFrame)
+        assertEqual(resolvedLiveFrame.size, CGSize(width: 200, height: 50))
+        XCTAssertNotNil(try XCTUnwrap(renderedProbeFrame))
+        try assertEqual(resolvedLiveFrame, XCTUnwrap(markerFrame))
+    }
+
+    private func blackPixelBounds(in image: UIImage) -> CGRect? {
+        let width = Int(image.size.width.rounded())
+        let height = Int(image.size.height.rounded())
+        let format = UIGraphicsImageRendererFormat()
+        format.scale = 1
+        format.opaque = true
+        format.preferredRange = .standard
+        let normalizedImage = UIGraphicsImageRenderer(size: image.size, format: format).image { _ in
+            UIColor.white.setFill()
+            UIRectFill(CGRect(origin: .zero, size: image.size))
+            image.draw(in: CGRect(origin: .zero, size: image.size))
+        }
+        guard let cgImage = normalizedImage.cgImage,
+              let data = cgImage.dataProvider?.data,
+              let pixels = CFDataGetBytePtr(data)
+        else {
+            return nil
+        }
+
+        var minX = width
+        var minY = height
+        var maxX = -1
+        var maxY = -1
+        let bytesPerPixel = cgImage.bitsPerPixel / 8
+        for y in 0 ..< height {
+            for x in 0 ..< width {
+                let offset = y * cgImage.bytesPerRow + x * bytesPerPixel
+                let darkByteCount = (0 ..< bytesPerPixel)
+                    .count { pixels[offset + $0] < 8 }
+                if darkByteCount >= bytesPerPixel * 3 / 4 {
+                    minX = min(minX, x)
+                    minY = min(minY, y)
+                    maxX = max(maxX, x)
+                    maxY = max(maxY, y)
+                }
+            }
+        }
+        guard maxX >= minX, maxY >= minY else { return nil }
+        return CGRect(
+            x: minX,
+            y: minY,
+            width: maxX - minX + 1,
+            height: maxY - minY + 1
+        )
+    }
+
+    private func nonWhitePixelBounds(in image: UIImage) -> CGRect? {
+        let width = Int(image.size.width.rounded())
+        let height = Int(image.size.height.rounded())
+        let format = UIGraphicsImageRendererFormat()
+        format.scale = 1
+        format.opaque = true
+        format.preferredRange = .standard
+        let normalizedImage = UIGraphicsImageRenderer(size: image.size, format: format).image { _ in
+            UIColor.white.setFill()
+            UIRectFill(CGRect(origin: .zero, size: image.size))
+            image.draw(in: CGRect(origin: .zero, size: image.size))
+        }
+        guard let cgImage = normalizedImage.cgImage,
+              let data = cgImage.dataProvider?.data,
+              let pixels = CFDataGetBytePtr(data)
+        else {
+            return nil
+        }
+
+        var minX = width
+        var minY = height
+        var maxX = -1
+        var maxY = -1
+        let bytesPerPixel = cgImage.bitsPerPixel / 8
+        for y in 0 ..< height {
+            for x in 0 ..< width {
+                let offset = y * cgImage.bytesPerRow + x * bytesPerPixel
+                let differsFromWhite = (0 ..< bytesPerPixel).contains { component in
+                    abs(Int(pixels[offset + component]) - Int(pixels[component])) > 2
+                }
+                if differsFromWhite {
+                    minX = min(minX, x)
+                    minY = min(minY, y)
+                    maxX = max(maxX, x)
+                    maxY = max(maxY, y)
+                }
+            }
+        }
+        guard maxX >= minX, maxY >= minY else { return nil }
+        return CGRect(
+            x: minX,
+            y: minY,
+            width: maxX - minX + 1,
+            height: maxY - minY + 1
+        )
+    }
+
+    private func resolvedOverlayFrame(for shape: AccessibilityShape) throws -> CGRect {
+        let root = ZStack(alignment: .topLeading) {
+            Color.white
+            ElementOverlay(
+                index: 0,
+                shape: shape,
+                palette: .modern
+            )
+        }
+        .frame(width: renderSize.width, height: renderSize.height)
+
+        let hosting = UIHostingController(rootView: root)
+        hosting.safeAreaRegions = []
+        hosting.view.frame = CGRect(origin: .zero, size: renderSize)
+        let window = host(hosting.view)
+        defer { window.isHidden = true }
+
+        hosting.view.setNeedsLayout()
+        hosting.view.layoutIfNeeded()
+        let image = try hosting.view.renderToImage(
+            configuration: .init(renderMode: .renderLayerInContext, colorMode: .fullColor)
+        )
+        return try XCTUnwrap(nonWhitePixelBounds(in: image))
+    }
+
+    private func parsedMarker(label: String, in root: UIView) throws -> AccessibilityMarker {
+        let markers = AccessibilityHierarchyParser()
+            .parseAccessibilityHierarchy(in: root)
+            .flattenToElements()
+        return try XCTUnwrap(markers.first { $0.label == label })
+    }
+
+    private func host(_ view: UIView) -> UIWindow {
+        let window = UIWindow(frame: UIScreen.main.bounds)
+        let rootViewController = UIViewController()
+        window.rootViewController = rootViewController
+        window.makeKeyAndVisible()
+        view.center = rootViewController.view.center
+        rootViewController.view.addSubview(view)
+        view.setNeedsLayout()
+        view.layoutIfNeeded()
+        RunLoop.current.run(until: Date())
+        return window
+    }
+
+    private func assertEqual(
+        _ actual: CGRect,
+        _ expected: CGRect,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        assertEqual(actual.origin, expected.origin, file: file, line: line)
+        assertEqual(actual.size, expected.size, file: file, line: line)
+    }
+
+    private func assertEqual(
+        _ actual: CGPoint,
+        _ expected: CGPoint,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        let accuracy = 1 / UIScreen.main.scale
+        XCTAssertEqual(actual.x, expected.x, accuracy: accuracy, file: file, line: line)
+        XCTAssertEqual(actual.y, expected.y, accuracy: accuracy, file: file, line: line)
+    }
+
+    private func assertEqual(
+        _ actual: CGSize,
+        _ expected: CGSize,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        let accuracy = 1 / UIScreen.main.scale
+        XCTAssertEqual(actual.width, expected.width, accuracy: accuracy, file: file, line: line)
+        XCTAssertEqual(actual.height, expected.height, accuracy: accuracy, file: file, line: line)
+    }
+}
+
+@available(iOS 18.0, *)
+private final class CapturingSnapshotView: AccessibilitySnapshotBaseView {
+    private let capture: (ParsedAccessibilityData) -> Void
+
+    init(
+        containedView: UIView,
+        snapshotConfiguration: AccessibilitySnapshotConfiguration,
+        capture: @escaping (ParsedAccessibilityData) -> Void
+    ) {
+        self.capture = capture
+        super.init(containedView: containedView, snapshotConfiguration: snapshotConfiguration)
+    }
+
+    override func render(data: ParsedAccessibilityData) {
+        capture(data)
+    }
+}
+
+@available(iOS 18.0, *)
+@MainActor
+private final class AnchorBox {
+    weak var view: UIView?
+}
+
+@available(iOS 18.0, *)
+private struct AnchorView: UIViewRepresentable {
+    let box: AnchorBox
+
+    func makeUIView(context: Context) -> UIView {
+        let view = UIView()
+        box.view = view
+        return view
+    }
+
+    func updateUIView(_ uiView: UIView, context: Context) {
+        box.view = uiView
+    }
+}
+
+private extension AccessibilityShape {
+    var boundingBox: CGRect {
+        switch self {
+        case let .frame(rect):
+            rect.cgRect
+        case let .path(path):
+            path.cgPath.boundingBox
+        }
+    }
+}
+
+private extension CGRect {
+    var center: CGPoint {
+        CGPoint(x: midX, y: midY)
+    }
+}

--- a/Example/Project.swift
+++ b/Example/Project.swift
@@ -289,6 +289,10 @@ let project = Project(
             deploymentTargets: .iOS("18.0"),
             sources: ["AccessibilitySnapshotPreviewsTests/**/*.swift"],
             dependencies: [
+                .target(name: "AccessibilitySnapshotCore"),
+                .target(name: "AccessibilitySnapshotModel"),
+                .target(name: "AccessibilitySnapshotParser"),
+                .target(name: "AccessibilitySnapshotPreviews"),
                 .target(name: "AccessibilitySnapshotPreviewsDemo"),
                 .target(name: "FBSnapshotTestCase_Accessibility"),
                 .external(name: "iOSSnapshotTestCase"),

--- a/Sources/AccessibilitySnapshot/Core/AccessibilitySnapshotBaseView.swift
+++ b/Sources/AccessibilitySnapshot/Core/AccessibilitySnapshotBaseView.swift
@@ -65,22 +65,42 @@ open class AccessibilitySnapshotBaseView: SnapshotAndLegendView {
     public func parseAccessibility() throws {
         cleanup()
 
-        let viewController = containedView.next as? UIViewController
-        let originalParent = viewController?.parent
+        let containedViewControllers = containedView.owningViewControllers()
+        let containedViewControllerSet = Set(containedViewControllers.map(ObjectIdentifier.init))
+        let rootViewControllers = containedViewControllers.filter { viewController in
+            viewController.parent.map { !containedViewControllerSet.contains(ObjectIdentifier($0)) } ?? true
+        }
+        let originalParents = rootViewControllers.map { ($0, $0.parent) }
         let originalSuperviewAndIndex = containedView.superviewWithSubviewIndex()
+        let snapshotParent = sequence(first: next, next: { $0?.next })
+            .first { $0 is UIViewController } as? UIViewController
 
-        viewController?.removeFromParent()
+        for viewController in rootViewControllers {
+            viewController.willMove(toParent: nil)
+            viewController.removeFromParent()
+        }
         addSubview(containedView)
+        if let snapshotParent {
+            for viewController in rootViewControllers {
+                snapshotParent.addChild(viewController)
+                viewController.didMove(toParent: snapshotParent)
+            }
+        }
 
         defer {
+            for viewController in rootViewControllers {
+                viewController.willMove(toParent: nil)
+                viewController.removeFromParent()
+            }
             containedView.removeFromSuperview()
 
             if let (originalSuperview, originalSubviewIndex) = originalSuperviewAndIndex {
                 originalSuperview.insertSubview(containedView, at: originalSubviewIndex)
             }
 
-            if let viewController = viewController, let originalParent = originalParent {
+            for case let (viewController, originalParent?) in originalParents {
                 originalParent.addChild(viewController)
+                viewController.didMove(toParent: originalParent)
             }
         }
 
@@ -127,6 +147,24 @@ open class AccessibilitySnapshotBaseView: SnapshotAndLegendView {
 // MARK: - Helper Extension
 
 extension UIView {
+    func owningViewControllers() -> [UIViewController] {
+        var result: [UIViewController] = []
+        var seen: Set<ObjectIdentifier> = []
+
+        func visit(_ view: UIView) {
+            if let viewController = view.next as? UIViewController,
+               viewController.view === view,
+               seen.insert(ObjectIdentifier(viewController)).inserted
+            {
+                result.append(viewController)
+            }
+            view.subviews.forEach(visit)
+        }
+
+        visit(self)
+        return result
+    }
+
     /// Returns the superview and the index of this view within the superview's subviews array.
     func superviewWithSubviewIndex() -> (UIView, Int)? {
         guard let superview = superview else {

--- a/Sources/AccessibilitySnapshot/Core/UIView+ImageRendering.swift
+++ b/Sources/AccessibilitySnapshot/Core/UIView+ImageRendering.swift
@@ -139,20 +139,53 @@ extension UIView {
         }
 
         let originalSafeAreaInsets = safeAreaInsets
+        let originalSuperview = superview
+        let originalOrigin = frame.origin
+        let originalAutoresizingMask = autoresizingMask
+        let presentationViewController = sequence(first: originalSuperview?.next, next: { $0?.next })
+            .first { $0 is UIViewController } as? UIViewController
 
-        // A view's safe area is governed by the nearest view controller in its responder chain: changes to a plain
-        // view's geometry or ancestry do not reliably invalidate its safe area, and a view controller's
-        // `additionalSafeAreaInsets` only affect the views it manages. Capture the view's own view controller if it
-        // has one, or adopt the view into a temporary view controller otherwise, so that the safe area can be
-        // restored below through a controller that actually governs this view.
+        let responderOwnedViewControllers = owningViewControllers()
+        let parentedViewControllers = presentationViewController?.children.filter {
+            $0.view === self || $0.view.isDescendant(of: self)
+        } ?? []
+        let containedViewControllers = (responderOwnedViewControllers + parentedViewControllers)
+            .reduce(into: [UIViewController]()) { result, viewController in
+                if !result.contains(where: { $0 === viewController }) {
+                    result.append(viewController)
+                }
+            }
+        let containedViewControllerSet = Set(containedViewControllers.map(ObjectIdentifier.init))
+        let rootViewControllers = containedViewControllers.filter { viewController in
+            viewController.parent.map { !containedViewControllerSet.contains(ObjectIdentifier($0)) } ?? true
+        }
+        let originalParents = rootViewControllers.map { ($0, $0.parent) }
+
+        // A view's safe area is governed by its view controller: changes to a plain view's geometry or ancestry do
+        // not reliably invalidate its safe area, and a view controller's `additionalSafeAreaInsets` only affect the
+        // views it manages. Capture the view's own view controller if it has one, or adopt the view and any nested
+        // child controllers into a temporary controller otherwise, so that the safe area can be restored below
+        // through a controller that actually governs this view.
         let adoptingViewController: UIViewController?
         let governingViewController: UIViewController
         if let owningViewController = next as? UIViewController {
             adoptingViewController = nil
             governingViewController = owningViewController
         } else {
+            for viewController in rootViewControllers {
+                viewController.willMove(toParent: nil)
+                viewController.removeFromParent()
+            }
             let viewController = UIViewController()
             viewController.view = self
+            for childViewController in rootViewControllers {
+                viewController.addChild(childViewController)
+                childViewController.didMove(toParent: viewController)
+            }
+            if let presentationViewController {
+                presentationViewController.addChild(viewController)
+                viewController.didMove(toParent: presentationViewController)
+            }
             adoptingViewController = viewController
             governingViewController = viewController
         }
@@ -161,18 +194,26 @@ extension UIView {
         defer {
             governingViewController.additionalSafeAreaInsets = originalAdditionalSafeAreaInsets
 
-            // Detach the view from the temporary view controller by giving the controller a new view, restoring the
-            // view's original responder chain.
-            adoptingViewController?.view = UIView()
-        }
-
-        let originalSuperview = superview
-        let originalOrigin = frame.origin
-        let originalAutoresizingMask = autoresizingMask
-        defer {
+            if let adoptingViewController {
+                for viewController in rootViewControllers {
+                    viewController.willMove(toParent: nil)
+                    viewController.removeFromParent()
+                }
+                adoptingViewController.willMove(toParent: nil)
+                adoptingViewController.removeFromParent()
+                // Detach the view from the temporary view controller by giving the controller a new view, restoring
+                // the view's original responder chain.
+                adoptingViewController.view = UIView()
+            }
             originalSuperview?.addSubview(self)
             frame.origin = originalOrigin
             autoresizingMask = originalAutoresizingMask
+            if adoptingViewController != nil {
+                for case let (viewController, originalParent?) in originalParents {
+                    originalParent.addChild(viewController)
+                    viewController.didMove(toParent: originalParent)
+                }
+            }
         }
 
         let frameView = UIView(frame: frame)


### PR DESCRIPTION
Please don't review yet, verifying this myself!

> _Posted by an AI agent on kyleve's behalf._

## Summary

- preserve nested view-controller containment while accessibility snapshots temporarily reparent their rendered view
- keep SwiftUI layout, safe-area geometry, rendered pixels, and parsed accessibility frames in the same coordinate space
- cover UIKit, SwiftUI, safe-area, wrapper-reparenting, tiled-rendering, frame-overlay, and path-overlay alignment numerically

## Why

A SwiftUI hosting controller could remain attached to its original parent while its view was moved into the snapshot container. `drawHierarchy(in:afterScreenUpdates:)` then recomputed the view using inconsistent controller containment, while accessibility parsing observed the post-render hierarchy. In the reproduced calendar case, the rendered content moved down by 32 points but the accessibility frames did not, making every overlay appear uniformly too high.

The fix temporarily moves the relevant root view controllers with their views and restores the original hierarchy after capture. The tiled rendering path uses the same ownership model when it adopts a view into a temporary controller. No global coordinate adjustment is applied.

## Review focus

- controller discovery and restoration in `AccessibilitySnapshotBaseView.parseAccessibility()`
- temporary controller adoption in the tiled hierarchy renderer
- whether the numerical harness covers the ownership shapes the library intends to support

## Testing

- `mise exec -- swiftformat Example/Project.swift Example/AccessibilitySnapshotPreviewsTests/OverlayAlignmentTests.swift Sources/AccessibilitySnapshot/Core/AccessibilitySnapshotBaseView.swift Sources/AccessibilitySnapshot/Core/UIView+ImageRendering.swift --lint`
- focused `OverlayAlignmentTests` matrix: 7 tests passed on iOS 27
- detached consumer verification against Stuff's calendar accessibility snapshot: corrected reference reran green
- the repository's existing preview snapshot matrix was not recorded because its test harness intentionally supports only iOS 18.5 and 26.2; neither runtime is installed in this environment
