### PR TITLE
Add ref-free AccessibilityVisibility and DerivedContext model types

### DIFF
--- a/AccessibilitySnapshotModel/Sources/AccessibilitySnapshotModel/AccessibilityVisibility.swift
+++ b/AccessibilitySnapshotModel/Sources/AccessibilitySnapshotModel/AccessibilityVisibility.swift
@@ -1,0 +1,13 @@
+/// Whether an element was on screen at parse time.
+///
+/// The parser always walks the full accessibility tree and stamps this flag; the decision to
+/// omit off-screen elements is made later, at delivery time. Only the parser has the UIKit context
+/// (scroll offsets, inset-adjusted bounds) needed to compute it, so it is recorded here rather than
+/// derived downstream.
+public enum AccessibilityVisibility: String, Hashable, Codable, Sendable {
+    /// The element's visible frame intersects the visible region of every scrollable ancestor.
+    case onscreen
+
+    /// The element is clipped out by a scrollable ancestor (or an off-screen ancestor).
+    case offscreen
+}

--- a/AccessibilitySnapshotModel/Sources/AccessibilitySnapshotModel/DerivedContext.swift
+++ b/AccessibilitySnapshotModel/Sources/AccessibilitySnapshotModel/DerivedContext.swift
@@ -1,0 +1,81 @@
+import Foundation
+
+/// Ref-free container context derived from an element's position in the graph at delivery time.
+///
+/// This is the model-side mirror of the Parser's `AccessibilityHierarchyParser.Context`, but it
+/// carries no live UIKit references — data-table headers are resolved to their text (`HeaderText`)
+/// at derivation, not held as `NSObject`s. That is what lets description assembly run late, on any
+/// platform, without holding live UIKit references past the parse.
+public enum DerivedContext: Hashable, Sendable {
+    /// The element is part of a series. Reads as "`index` of `count`."
+    case series(index: Int, count: Int)
+
+    /// The element is a tab in a `UITabBar`. Reads as "Tab. `index` of `count`."
+    case tabBarItem(index: Int, count: Int)
+
+    /// The element is a tab in a `.tabBar`-trait container. Reads as "Tab. `index` of `count`."
+    case tab(index: Int, count: Int)
+
+    /// The element is a cell in a data table.
+    ///
+    /// - `row` / `column`: zero-based position, or `NSNotFound` when unknown.
+    /// - `width` / `height`: number of columns / rows the cell spans.
+    /// - `isFirstInRow`: whether VoiceOver reads this as the first cell in its row.
+    /// - `rowHeaders` / `columnHeaders`: the resolved header text VoiceOver reads before the cell.
+    case dataTableCell(
+        row: Int,
+        column: Int,
+        width: Int,
+        height: Int,
+        isFirstInRow: Bool,
+        rowHeaders: [HeaderText],
+        columnHeaders: [HeaderText]
+    )
+
+    /// The element is the first element in a list.
+    case listStart
+
+    /// The element is the last element in a list. (A sole element gets only `listStart`.)
+    case listEnd
+
+    /// The element is the first element in a landmark container.
+    case landmarkStart
+
+    /// The element is the last element in a landmark container. (A sole element gets only `landmarkStart`.)
+    case landmarkEnd
+
+    /// A data-table header's resolved text, extracted from the header element's label/value.
+    public struct HeaderText: Hashable, Sendable {
+        public let label: String?
+        public let value: String?
+
+        public init(label: String?, value: String?) {
+            self.label = label
+            self.value = value
+        }
+    }
+}
+
+// MARK: - Trait-hiding rules keyed on context
+
+extension DerivedContext {
+    /// Whether the container context suppresses the element's own "Button." trait specifier.
+    var hidesButtonTrait: Bool {
+        switch self {
+        case .series, .tabBarItem, .dataTableCell, .listStart, .listEnd, .landmarkStart, .landmarkEnd:
+            return false
+        case .tab:
+            return true
+        }
+    }
+
+    /// Whether the container context adds a "Tab." trait specifier the element itself doesn't carry.
+    var showsTabTrait: Bool {
+        switch self {
+        case .series, .dataTableCell, .listStart, .listEnd, .landmarkStart, .landmarkEnd:
+            return false
+        case .tab, .tabBarItem:
+            return true
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Introduces two model-side value types that let container context and element visibility be represented **without holding live UIKit references**. These are the foundation for moving description assembly to delivery time and for removing the parser's post-walk context loopback — but this PR is just the vocabulary; no parser behavior changes.

### `AccessibilityVisibility`
An on/off-screen flag the parser stamps during the walk. Only the parser has the UIKit context (scroll offsets, inset-adjusted bounds) to compute it, so it's recorded at parse time — which lets the *decision* to omit off-screen elements move to delivery time rather than being baked into the walk.

### `DerivedContext`
A ref-free mirror of `AccessibilityHierarchyParser.Context`. Same cases (`series`, `tabBarItem`, `tab`, `dataTableCell`, list/landmark boundaries), with one deliberate difference: data-table headers are carried as **resolved text** (`HeaderText`), not live `NSObject`s. That's what allows description assembly to run late, on any platform, without a post-walk reach back into live objects.

## Scope / sequencing

This is intentionally small and self-contained — the two type definitions only. It builds against the model target in isolation with no dependencies beyond what's already here.

Deliberately **not** included (each is its own follow-up, and each depends on this landing first):
- The derivation that populates `DerivedContext` from graph position — it depends on extending `AccessibilityContainer` (resolved data-table cells, additional container types).
- The parser change that replaces the `contextProvider` loopback with graph-derived context.

Kept as a draft to align on the type shapes before the derivation and parser changes build on them.

## Testing

Model target builds in isolation (`swift build --target AccessibilitySnapshotModel`). Pure value types, UIKit-free; behavioral tests arrive with the derivation PR that consumes them.