### PR TITLE
Make snapshot engine dependencies optional with package traits.

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,52 +1,51 @@
 {
-  "object": {
-    "pins": [
-      {
-        "package": "iOSSnapshotTestCase",
-        "repositoryURL": "https://github.com/uber/ios-snapshot-test-case.git",
-        "state": {
-          "branch": null,
-          "revision": "7b10770333a961be6e5a41c9ce04b8c6d3990126",
-          "version": "8.0.0"
-        }
-      },
-      {
-        "package": "swift-custom-dump",
-        "repositoryURL": "https://github.com/pointfreeco/swift-custom-dump",
-        "state": {
-          "branch": null,
-          "revision": "2a2a938798236b8fa0bc57c453ee9de9f9ec3ab0",
-          "version": "1.4.1"
-        }
-      },
-      {
-        "package": "swift-snapshot-testing",
-        "repositoryURL": "https://github.com/pointfreeco/swift-snapshot-testing.git",
-        "state": {
-          "branch": null,
-          "revision": "bf8d8c27f0f0c6d5e77bff0db76ab68f2050d15d",
-          "version": "1.18.9"
-        }
-      },
-      {
-        "package": "swift-syntax",
-        "repositoryURL": "https://github.com/swiftlang/swift-syntax",
-        "state": {
-          "branch": null,
-          "revision": "4799286537280063c85a32f09884cfbca301b1a1",
-          "version": "602.0.0"
-        }
-      },
-      {
-        "package": "xctest-dynamic-overlay",
-        "repositoryURL": "https://github.com/pointfreeco/xctest-dynamic-overlay",
-        "state": {
-          "branch": null,
-          "revision": "34e463e98ab8541c604af706c99bed7160f5ec70",
-          "version": "1.8.1"
-        }
+  "originHash" : "02a469eb0087a639af0ced990890989857c267234d1dbf4f8d4a27f61042fff2",
+  "pins" : [
+    {
+      "identity" : "ios-snapshot-test-case",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/uber/ios-snapshot-test-case.git",
+      "state" : {
+        "revision" : "7b10770333a961be6e5a41c9ce04b8c6d3990126",
+        "version" : "8.0.0"
       }
-    ]
-  },
-  "version": 1
+    },
+    {
+      "identity" : "swift-custom-dump",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-custom-dump",
+      "state" : {
+        "revision" : "2a2a938798236b8fa0bc57c453ee9de9f9ec3ab0",
+        "version" : "1.4.1"
+      }
+    },
+    {
+      "identity" : "swift-snapshot-testing",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-snapshot-testing.git",
+      "state" : {
+        "revision" : "bf8d8c27f0f0c6d5e77bff0db76ab68f2050d15d",
+        "version" : "1.18.9"
+      }
+    },
+    {
+      "identity" : "swift-syntax",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-syntax",
+      "state" : {
+        "revision" : "4799286537280063c85a32f09884cfbca301b1a1",
+        "version" : "602.0.0"
+      }
+    },
+    {
+      "identity" : "xctest-dynamic-overlay",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
+      "state" : {
+        "revision" : "34e463e98ab8541c604af706c99bed7160f5ec70",
+        "version" : "1.8.1"
+      }
+    }
+  ],
+  "version" : 3
 }

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.3
+// swift-tools-version: 6.1
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -36,14 +36,20 @@ let package = Package(
             targets: ["AccessibilitySnapshotPreviews"]
         ),
     ],
+    traits: [
+        "SnapshotTesting",
+        "iOSSnapshotTestCase",
+        .default(enabledTraits: [
+            "SnapshotTesting",
+            "iOSSnapshotTestCase",
+        ]),
+    ],
     dependencies: [
         .package(
-            name: "iOSSnapshotTestCase",
             url: "https://github.com/uber/ios-snapshot-test-case.git",
             .upToNextMajor(from: "8.0.0")
         ),
         .package(
-            name: "SnapshotTesting",
             url: "https://github.com/pointfreeco/swift-snapshot-testing.git",
             .upToNextMajor(from: "1.10.0")
         ),
@@ -83,7 +89,11 @@ let package = Package(
                 "AccessibilitySnapshotCore",
                 "AccessibilitySnapshotParser-ObjC",
                 "AccessibilitySnapshotPreviews",
-                "SnapshotTesting",
+                .product(
+                    name: "SnapshotTesting",
+                    package: "swift-snapshot-testing",
+                    condition: .when(traits: ["SnapshotTesting"])
+                ),
             ],
             path: "Sources/AccessibilitySnapshot/SnapshotTesting"
         ),
@@ -93,14 +103,27 @@ let package = Package(
                 "AccessibilitySnapshotCore",
                 "AccessibilitySnapshotParser-ObjC",
                 "AccessibilitySnapshotPreviews",
-                "iOSSnapshotTestCase",
+                .product(
+                    name: "iOSSnapshotTestCase",
+                    package: "ios-snapshot-test-case",
+                    condition: .when(traits: ["iOSSnapshotTestCase"])
+                ),
             ],
             path: "Sources/AccessibilitySnapshot/iOSSnapshotTestCase/Swift"
         ),
         .target(
             name: "FBSnapshotTestCase-Accessibility-ObjC",
-            dependencies: ["AccessibilitySnapshotCore", "iOSSnapshotTestCase", "FBSnapshotTestCase-Accessibility"],
+            dependencies: [
+                "AccessibilitySnapshotCore",
+                .product(
+                    name: "iOSSnapshotTestCase",
+                    package: "ios-snapshot-test-case",
+                    condition: .when(traits: ["iOSSnapshotTestCase"])
+                ),
+                "FBSnapshotTestCase-Accessibility",
+            ],
             path: "Sources/AccessibilitySnapshot/iOSSnapshotTestCase/ObjC"
         ),
-    ]
+    ],
+    swiftLanguageModes: [.v5]
 )

--- a/Package@swift-5.3.swift
+++ b/Package@swift-5.3.swift
@@ -1,0 +1,106 @@
+// swift-tools-version:5.3
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "AccessibilitySnapshot",
+    defaultLocalization: "en",
+    platforms: [
+        .iOS(.v13),
+        .macOS(.v10_15),
+    ],
+    products: [
+        // Core + SnapshotTesting for image comparison
+        .library(
+            name: "AccessibilitySnapshot",
+            targets: ["AccessibilitySnapshot"]
+        ),
+        .library(
+            name: "FBSnapshotTestCase-Accessibility",
+            targets: [
+                "FBSnapshotTestCase-Accessibility",
+                "FBSnapshotTestCase-Accessibility-ObjC",
+            ]
+        ),
+        .library(
+            name: "AccessibilitySnapshotCore",
+            targets: ["AccessibilitySnapshotCore"]
+        ),
+        .library(
+            name: "AccessibilitySnapshotParser",
+            targets: ["AccessibilitySnapshotParser"]
+        ),
+        .library(
+            name: "AccessibilitySnapshotPreviews",
+            targets: ["AccessibilitySnapshotPreviews"]
+        ),
+    ],
+    dependencies: [
+        .package(
+            name: "iOSSnapshotTestCase",
+            url: "https://github.com/uber/ios-snapshot-test-case.git",
+            .upToNextMajor(from: "8.0.0")
+        ),
+        .package(
+            name: "SnapshotTesting",
+            url: "https://github.com/pointfreeco/swift-snapshot-testing.git",
+            .upToNextMajor(from: "1.10.0")
+        ),
+    ],
+    targets: [
+        .target(
+            name: "AccessibilitySnapshotModel",
+            path: "AccessibilitySnapshotModel/Sources/AccessibilitySnapshotModel"
+        ),
+        .target(
+            name: "AccessibilitySnapshotParser-ObjC",
+            path: "Sources/AccessibilitySnapshot/Parser/ObjC"
+        ),
+        .target(
+            name: "AccessibilitySnapshotParser",
+            dependencies: [
+                "AccessibilitySnapshotModel",
+                "AccessibilitySnapshotParser-ObjC",
+            ],
+            path: "Sources/AccessibilitySnapshot/Parser/Swift",
+            resources: [.process("Assets")]
+        ),
+        .target(
+            name: "AccessibilitySnapshotCore",
+            dependencies: ["AccessibilitySnapshotParser"],
+            path: "Sources/AccessibilitySnapshot/Core",
+            resources: [.process("Assets")]
+        ),
+        .target(
+            name: "AccessibilitySnapshotPreviews",
+            dependencies: ["AccessibilitySnapshotCore", "AccessibilitySnapshotParser"],
+            path: "Sources/AccessibilitySnapshot/AccessibilitySnapshotPreviews"
+        ),
+        .target(
+            name: "AccessibilitySnapshot",
+            dependencies: [
+                "AccessibilitySnapshotCore",
+                "AccessibilitySnapshotParser-ObjC",
+                "AccessibilitySnapshotPreviews",
+                "SnapshotTesting",
+            ],
+            path: "Sources/AccessibilitySnapshot/SnapshotTesting"
+        ),
+        .target(
+            name: "FBSnapshotTestCase-Accessibility",
+            dependencies: [
+                "AccessibilitySnapshotCore",
+                "AccessibilitySnapshotParser-ObjC",
+                "AccessibilitySnapshotPreviews",
+                "iOSSnapshotTestCase",
+            ],
+            path: "Sources/AccessibilitySnapshot/iOSSnapshotTestCase/Swift"
+        ),
+        .target(
+            name: "FBSnapshotTestCase-Accessibility-ObjC",
+            dependencies: ["AccessibilitySnapshotCore", "iOSSnapshotTestCase", "FBSnapshotTestCase-Accessibility"],
+            path: "Sources/AccessibilitySnapshot/iOSSnapshotTestCase/ObjC"
+        ),
+    ]
+)


### PR DESCRIPTION
Issue #361

Manifest-only (and `Package.resolved` if tools 6.1 rewrites the lockfile). Snapshot images don't change, so no new reference PNGs.

#361 asks whether to ship a non-breaking change (invalid trait combinations allowed) or a breaking one. This PR is (1).

1. Non-breaking. Traits `SnapshotTesting` and `iOSSnapshotTestCase`, both on by default. Same products, same targets, same `import`s. Clients who omit `traits:` keep today's graph. A client can still depend on an integration product with the matching trait off; that target will fail to compile.

## Why

`Package.swift` lists `ios-snapshot-test-case` and `swift-snapshot-testing` and the integration targets depend on them with no condition. SwiftPM checks out both for every client, even if you only use SnapshotTesting.

This PR gates those products with `condition: .when(traits:)`. With a trait off, SPM can skip that package.

## How

For backwards compatibility: both traits default on; products, targets, and `import`s are unchanged; `swiftLanguageModes` is `[.v5]` as tools 6.1 defaults to Swift 6 - which had errors.

Invalid product/trait pairs are left as invalid config (the sources still `import` the engine with no `#if`), so builds fail. This is preferable to the alternative of making all failing code compile conditionally - as it wouldn't be usable.

`Package@swift-5.3.swift` is the pre-traits manifest for SwiftPM 5.3–6.0.

`Package.swift` is now `swift-tools-version` 6.1. Using traits like below to make dependencies optional.

```swift
traits: [
    "SnapshotTesting",
    "iOSSnapshotTestCase",
    .default(enabledTraits: [
        "SnapshotTesting",
        "iOSSnapshotTestCase",
    ]),
]
…
.product(
    name: "SnapshotTesting",
    package: "swift-snapshot-testing",
    condition: .when(traits: ["SnapshotTesting"])
)
…
.product(
    name: "iOSSnapshotTestCase",
    package: "ios-snapshot-test-case",
    condition: .when(traits: ["iOSSnapshotTestCase"])
)
```

`AccessibilitySnapshotCore`, `AccessibilitySnapshotParser`, and `AccessibilitySnapshotPreviews` work with any traits.

`AccessibilitySnapshot` needs `SnapshotTesting`.

`FBSnapshotTestCase-Accessibility` needs `iOSSnapshotTestCase`.

## Usage

Default (omit `traits:`):

```swift
.package(
    url: "https://github.com/cashapp/AccessibilitySnapshot.git", from: "…"
)
```

All five products work. Same as today.

`SnapshotTesting` 

```swift
.package(
    url: "https://github.com/cashapp/AccessibilitySnapshot.git", from: "…",
    traits: ["SnapshotTesting"]
)
```

`AccessibilitySnapshot`, `AccessibilitySnapshotCore`, `AccessibilitySnapshotParser`, `AccessibilitySnapshotPreviews` work. Not `FBSnapshotTestCase-Accessibility`.

`iOSSnapshotTestCase`

```swift
.package(
    url: "https://github.com/cashapp/AccessibilitySnapshot.git", from: "…",
    traits: ["iOSSnapshotTestCase"]
)
```

`FBSnapshotTestCase-Accessibility`, `AccessibilitySnapshotCore`, `AccessibilitySnapshotParser`, `AccessibilitySnapshotPreviews` work. Not `AccessibilitySnapshot`.

`None` 

```swift
.package(
    url: "https://github.com/cashapp/AccessibilitySnapshot.git", from: "…",
    traits: []
)
```

`AccessibilitySnapshotCore`, `AccessibilitySnapshotParser`, `AccessibilitySnapshotPreviews` only.

## Tests

No snapshot output change, so no new reference images.

- [ ] `swift package dump-package` shows `SnapshotTesting` and `iOSSnapshotTestCase`, both in `default`
- [ ] Default traits still compile both integration products
- [ ] `traits: ["SnapshotTesting"]` does not resolve `ios-snapshot-test-case`
- [ ] `traits: ["iOSSnapshotTestCase"]` does not resolve `swift-snapshot-testing`
- [ ] `traits: []` plus `AccessibilitySnapshotCore` does not resolve either engine
- [ ] Example / Tuist tests still use the same imports

---

- [x] CLA signed